### PR TITLE
Fix for a broken link in http://gembundler.com/man/gemfile.5.html

### DIFF
--- a/ronn/gemfile.ronn
+++ b/ronn/gemfile.ronn
@@ -97,7 +97,7 @@ are obviously not available).
 Note that on `bundle install`, bundler downloads and evaluates all gems, in order to
 create a single canonical list of all of the required gems and their dependencies.
 This means that you cannot list different versions of the same gems in different
-groups. For more details, see [Understanding Bundler](http://gembundler.com/v1.0/understanding.html).
+groups. For more details, see [Understanding Bundler](http://gembundler.com/v1.0/rationale.html).
 
 ### PLATFORMS (:platforms)
 


### PR DESCRIPTION
In http://gembundler.com/man/gemfile.5.html the link to “Understanding Bundler” is broken.
