### PR TITLE
Bundle config flags - a little more clarity in the FAQ?

### DIFF
--- a/src/pages/rationale.haml
+++ b/src/pages/rationale.haml
@@ -582,6 +582,14 @@
     a result, once you specify the necessary build flags for a gem, you can successfully
     install that gem as many times as necessary.
 
+  %p
+    For instance, if you are deploying via Capistrano to a server that needs certain flags
+    set, you should log in as your deploy user and run the appropriate <code>bundle config
+    </code> command. This ensures that the appropriate configuration flags are available at
+    <code>~/.bundle/config</code> each time the particular gem is installed on that server.
+    As Bundler expects a Gemfile, you may want to temporarily <code>touch Gemfile</code> in
+    the deploy user's home directory to run the command.
+
 
   %h2#summary
     Summary


### PR DESCRIPTION
To get the pg gem building successfully on a Capistrano deployment to a CentOS server using Bundler, I needed to log in as my deploy user, touch Gemfile (as it's a new deployment / server there's no project to work out of), and bundle config build.pg --with-pg-config=/usr/pgsql-9.0/bin/pg_config to create the ~/.bundle/config file with appropriate arguments (as the CentOS yum package for the latest PostgreSQL has changed paths).

At the time it wasn't immediately clear from the FAQ that I had to do this, and unless I've missed a saner way to go about this (not sure [adding a rake task](http://railsonpostgresql.com/2010/09/16/rails-3-bundler-and-the-pg-gem) is ideal, considering flags are server-specific, not project-specific), I'd expect anyone else on CentOS using the latest PostgreSQL version will run into this problem (so perhaps the slightly exasperated 'If you really need to...' outline is missing a wider use-case for specifying flags?).
