### PR TITLE
Fix the run command in the sinatra docs

### DIFF
--- a/src/pages/sinatra.haml
+++ b/src/pages/sinatra.haml
@@ -17,7 +17,7 @@
       Bundler.require
 
       require './my_sinatra_app'
-      run MySinatraApp
+      run Sinatra::Application
 
   .bullet
     .description


### PR DESCRIPTION
Hi,

I had to change the run command in config.ru to have my Sinatra application be started without errors. I use the instruction from http://devcenter.heroku.com/articles/rack#frameworks. I am new to Sinatra, so frankly I don't know why it was not working with the Bundler documentation default instruction.
