### PR TITLE
Explanation of approximate dependencies incorrect

### DIFF
--- a/src/pages/gemfile.haml
+++ b/src/pages/gemfile.haml
@@ -35,7 +35,7 @@
       Most of the version specifiers, like <code>>= 1.0</code>, are self-explanatory.
       The specifier <code>~></code> has a special meaning, best shown by example.
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
-      <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 2.2</code>.
+      <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
 
   .bullet


### PR DESCRIPTION
The existing explanation of this operator was incorrect. I've tested it in Bundler and it works identically to the operator in RubyGems, the docs for which say:

> Notice that we only include 2 digits of the version. The operator will drop the final digit of a version, then increment the remaining final digit to get the upper limit version number. Therefore ‘~> 2.2’ is equivalent to: [‘>= 2.2’, ‘< 3.0’]. Had we said ‘~> 2.2.0’, it would have been equivalent to: [‘>= 2.2.0’, ‘< 2.3.0’].

See [the RubyGems docs](http://docs.rubygems.org/read/chapter/16#page74) for more info.

It might also be worth adding a link to these docs in the Bundler docs as a kind of explicit acknowledgement that Bundler's semantics for this operator are identical to RubyGems'.

Finally, mentioning **any** sort of Googleable phrase for this operator would help newbies. Some call it the _spermy operator_, though it is understandable that one might wish to avoid this. RubyGems calls it the _pessimistic operator_, read as _approximately greater than_.
