### PR TITLE
Fix for #1780 of Bundler

### DIFF
--- a/ronn/bundle-install.ronn
+++ b/ronn/bundle-install.ronn
@@ -14,7 +14,7 @@ time you run bundle install (and a `Gemfile.lock` does not exist),
 bundler will fetch all remote sources, resolve dependencies and
 install all needed gems.
 
-Note that gem installed from a git repository will not show up
+Note that gem installed using the :git or :path option will not show up
 in <code>gem list</code>.
 
 If a `Gemfile.lock` does exist, and you have not updated your `Gemfile`,
@@ -41,7 +41,7 @@ update process below under [CONSERVATIVE UPDATING][].
   to the gem home, which is the location that `gem install` installs
   gems to. This means that, by default, gems installed without a
   `--path` setting will show up in `gem list` except for gems coming
-  from a git repository. This setting is a
+  from a git repository or a path. This setting is a
   [remembered option][REMEMBERED OPTIONS].
 
 * `--system`:


### PR DESCRIPTION
Added some documentation about the fact that git managed gems are not visible in gem list.

https://github.com/carlhuda/bundler/issues/1780
