### PR TITLE
Use https for rubygems source

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -24,7 +24,7 @@
     .description
       Specify your dependencies in a Gemfile in your project's root:
     :highlight_ruby
-      source "http://rubygems.org"
+      source "https://rubygems.org"
       gem "nokogiri"
       gem "rack", "~>1.1"
       gem "rspec", :require => "spec"


### PR DESCRIPTION
http will redirect, but https is recommended
