### PR TITLE
Bundle path is /vendor/bundle not vendor/bundler

### DIFF
--- a/src/pages/v1.2/bundle_config.haml
+++ b/src/pages/v1.2/bundle_config.haml
@@ -158,7 +158,7 @@
         %li 
           <code>path</code> (<code>BUNDLE_PATH</code>): The location on disk 
           to install gems. Defaults to <code>$GEM_HOME</code> in development 
-          and <code>vendor/bundler</code> when <code>--deployment</code> is used.
+          and <code>vendor/bundle</code> when <code>--deployment</code> is used.
         %li 
           <code>frozen</code> (<code>BUNDLE_FROZEN</code>): Disallow changes to 
           the <code>Gemfile</code>. Defaults to <code>true</code> when 


### PR DESCRIPTION
Small typo, but when I was reading the `bundler config` docs I was confused since I thought it was `vendor/bundle`, at least according to this code: https://github.com/carlhuda/bundler/blob/master/lib/bundler/cli.rb#L216
