### PR TITLE
Remove documentation about standalone git tag

### DIFF
--- a/source/v1.3/gemfile.haml
+++ b/source/v1.3/gemfile.haml
@@ -57,9 +57,6 @@
       <code>:branch</code>, or <code>:ref</code>. The default is the <code>master</code> branch.
     :highlight_ruby
       gem 'nokogiri', :git => 'git://github.com/tenderlove/nokogiri.git', :branch => '1.4'
-
-      git 'git://github.com/wycats/thor.git', :tag => 'v0.13.4'
-      gem 'thor'
     .notes
       If the git repository does not contain a <code>.gemspec</code> file, bundler
       will create a simple one, without any dependencies, executables or C extensions.


### PR DESCRIPTION
Specify a git source by itself is no longer supported in the latest version of Bundler.

```
  You can no longer specify a git source by itself. Instead, 
  either use the :git option on a gem, or specify the gems that 
  bundler should find in the git source by passing a block to 
  the git method, like: 

    git 'git://github.com/rails/rails.git' do
      gem 'rails'
    end
```
