### PR TITLE
Fix 'Configuring Bundler' links.

### DIFF
--- a/source/v1.0/rationale.haml
+++ b/source/v1.0/rationale.haml
@@ -187,8 +187,8 @@
     <code>APP_ROOT/.bundle/config</code>. You can see all of the settings that bundler saved
     there by running <code>bundle config</code>, which will also print out global settings
     (stored in <code>~/.bundle/config</code>), and settings set via environment variables.
-    For more information on configuring bundler, please see [Advanced Usage: Configuring
-    Bundler](http://gembundler.com/v1.0/configuring.html).
+    For more information on configuring bundler, please see
+    #{link_to 'bundle config', './man/bundle-config.1.html'}.
 
   %p
     If you run <code>bundle install</code> later, without any flag, bundler will remember

--- a/source/v1.1/rationale.haml
+++ b/source/v1.1/rationale.haml
@@ -187,8 +187,8 @@
     <code>APP_ROOT/.bundle/config</code>. You can see all of the settings that bundler saved
     there by running <code>bundle config</code>, which will also print out global settings
     (stored in <code>~/.bundle/config</code>), and settings set via environment variables.
-    For more information on configuring bundler, please see [Advanced Usage: Configuring
-    Bundler](http://gembundler.com/v1.0/configuring.html).
+    For more information on configuring bundler, please see
+    #{link_to 'bundle config', './man/bundle-config.1.html'}.
 
   %p
     If you run <code>bundle install</code> later, without any flag, bundler will remember

--- a/source/v1.2/rationale.haml
+++ b/source/v1.2/rationale.haml
@@ -187,8 +187,8 @@
     <code>APP_ROOT/.bundle/config</code>. You can see all of the settings that bundler saved
     there by running <code>bundle config</code>, which will also print out global settings
     (stored in <code>~/.bundle/config</code>), and settings set via environment variables.
-    For more information on configuring bundler, please see [Advanced Usage: Configuring
-    Bundler](http://gembundler.com/v1.0/configuring.html).
+    For more information on configuring bundler, please see
+    #{link_to 'bundle config', './bundle_config.html'}.
 
   %p
     If you run <code>bundle install</code> later, without any flag, bundler will remember

--- a/source/v1.3/rationale.haml
+++ b/source/v1.3/rationale.haml
@@ -187,8 +187,8 @@
     <code>APP_ROOT/.bundle/config</code>. You can see all of the settings that bundler saved
     there by running <code>bundle config</code>, which will also print out global settings
     (stored in <code>~/.bundle/config</code>), and settings set via environment variables.
-    For more information on configuring bundler, please see [Advanced Usage: Configuring
-    Bundler](http://gembundler.com/v1.0/configuring.html).
+    For more information on configuring bundler, please see
+    #{link_to 'bundle config', './bundle_config.html'}.
 
   %p
     If you run <code>bundle install</code> later, without any flag, bundler will remember


### PR DESCRIPTION
Now these point to the right version of the documentation for 'bundle config': the command documentation for verions 1.2 and 1.3, and the HTML man page for versions 1.0 and 1.1 (before the command page was complete).
