### PR TITLE
Make latest docs available at the top level.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,9 @@ task :man => [:update_vendor] do
     end
 
   end
+
+  # Make man pages for the latest version available at the top level, too.
+  cp_r "build/v1.3/man", "build/man"
 end
 
 desc "Build the static site"

--- a/config.rb
+++ b/config.rb
@@ -39,6 +39,17 @@ activate :livereload
 #   @which_fake_page = "Rendering a fake page with a variable"
 # end
 
+# Make documentation for the latest version available at the top level, too.
+# Any pages with names that conflict with files already at the top level will be skipped.
+ready do
+  sitemap.resources.each do |page|
+    if page.path.start_with? 'v1.3/'
+      proxy_path = page.path['v1.3/'.length..-1]
+      proxy proxy_path, page.path if sitemap.find_resource_by_path(proxy_path).nil?
+    end
+  end
+end
+
 ###
 # Helpers
 ###


### PR DESCRIPTION
There are broken links in the wild to top-level pages that were moved into versioned directories.

For example, the Gemfile(5) man page links to http://gembundler.com/rationale.html and the [Capistrano](http://capistranorb.com/) home page links to http://gembundler.com/deploying.html.

This pull request deals with the problem by copying each page from v1.3 into the root directory at build time. It's maybe a bit heavy-handed, but should cope with any links out there and ensures that relative links from one doc page to another still work. Man pages are also copied from v1.3/man to /man.

The index and layout links still go to the versioned pages in v1.3, to encourage people to use versioned links when they copy the URL from the browser. It is kind of nice to have a permalink for the latest version of a particular page, though.

This would also allow the top-level index.haml to be moved into the v1.3 directory (though I haven't done that in this pull request). Right now the other versions have an index page but v1.3 doesn't, so http://gembundler.com/v1.2/ gives you something useful and http://gembundler.com/v1.3/ 404s.
