### PR TITLE
Update references to the bundler repository URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # gembundler.com
-gembundler.com is intended to serve as a convenient source for documentation on the [bundler](https://github.com/carlhuda/bundler) gem. 
+gembundler.com is intended to serve as a convenient source for documentation on the [bundler](https://github.com/bundler/bundler) gem. 
 
 The site gembundler.com is a static site generated using [Middleman](http://middlemanapp.com/).
 
-[Bundler's manual pages](https://github.com/carlhuda/bundler/tree/master/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
+[Bundler's manual pages](https://github.com/bundler/bundler/tree/master/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
 
 ## Basic Middleman Commands
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,10 @@ require "bundler/setup"
 
 directory "vendor"
 directory "vendor/bundler" => ["vendor"] do
-  system "git clone git@github.com:carlhuda/bundler.git vendor/bundler"
+  system "git clone git@github.com:bundler/bundler.git vendor/bundler"
   # Some users don't have private permissions
   if !File.exist?("vendor/bundler")
-    system "git clone git://github.com/carlhuda/bundler.git vendor/bundler"
+    system "git clone git://github.com/bundler/bundler.git vendor/bundler"
   end
 end
 
@@ -39,7 +39,7 @@ task :build do
   sh "middleman build --clean"
 end
 
-desc "Release the current commit to carlhuda/bundler@gh-pages"
+desc "Release the current commit to bundler/bundler@gh-pages"
 task :release => [:update_vendor, :build, :man] do
   commit = `git rev-parse HEAD`.chomp
 
@@ -51,7 +51,7 @@ task :release => [:update_vendor, :build, :man] do
     File.write("CNAME", "gembundler.com")
 
     sh "git add -A ."
-    sh "git commit -m 'carlhuda/bundler-site-middleman@#{commit}'"
+    sh "git commit -m 'bundler/bundler-site@#{commit}'"
     sh "git push origin gh-pages"
   end
 end

--- a/source/contributors.haml
+++ b/source/contributors.haml
@@ -18,7 +18,7 @@
   %h3== Carl Lerche (#{link_to '@carllerche', 'https://github.com/carllerche'})
   %h4 Core Team Alumni
 
-%p== And with support and commits provided by #{link_to 'many other contributors…', 'http://github.com/carlhuda/bundler/contributors'}
+%p== And with support and commits provided by #{link_to 'many other contributors…', 'http://github.com/bundler/bundler/contributors'}
 
 %h2 Icon and Logo
 %p

--- a/source/index.haml
+++ b/source/index.haml
@@ -6,7 +6,7 @@
 %h2 Would you like to
 .buttons
   = link_to 'Get started', '#getting-started'
-  = link_to 'Report a bug', 'https://github.com/carlhuda/bundler/blob/master/ISSUES.md'
+  = link_to 'Report a bug', 'https://github.com/bundler/bundler/blob/master/ISSUES.md'
   = link_to "See what's new", '/v1.3/whats_new.html'
   = link_to 'Read documentation', '#use-bundler'
 
@@ -102,7 +102,7 @@
 .buttons
   = link_to '#bundler on IRC', 'http://webchat.freenode.net/?channels=bundler'
   = link_to 'Mailing list', 'http://groups.google.com/group/ruby-bundler'
-  = link_to 'Contributing', 'https://github.com/carlhuda/bundler/blob/master/CONTRIBUTE.md'
+  = link_to 'Contributing', 'https://github.com/bundler/bundler/blob/master/CONTRIBUTE.md'
   = link_to 'Core team', 'mailto:andre.arko+terence.lee@gmail.com'
 
 .shirts

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -62,7 +62,7 @@
       %p
         == Many thanks to Bundler's #{link_to 'contributors', '/contributors.html' }
         == and #{link_to 'sponsors', '/sponsors.html' }
-    %a#github{ :href => 'http://github.com/carlhuda/bundler/' }
+    %a#github{ :href => 'http://github.com/bundler/bundler/' }
       %img{ :src => 'http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png', :alt => 'Fork me on GitHub' }
     #prod-versions
       Docs:

--- a/source/sponsors.haml
+++ b/source/sponsors.haml
@@ -20,7 +20,7 @@
 .contributor
   = link_to image_tag("sponsors/travis.png", :class => "avatar"), "http://travis-ci.org"
   %h3== #{link_to 'Travis CI', 'http://travis-ci.org'}
-  %p== Travis provides #{link_to "Bundler's continuous integration", 'http://travis-ci.org/carlhuda/bundler/'} infrastructure, which uses servers donated by #{link_to 'BlueBox', 'http://bluebox.net'} to automatically test Bundler against all of the Ruby and Rubygems versions that we support.
+  %p== Travis provides #{link_to "Bundler's continuous integration", 'http://travis-ci.org/bundler/bundler/'} infrastructure, which uses servers donated by #{link_to 'BlueBox', 'http://bluebox.net'} to automatically test Bundler against all of the Ruby and Rubygems versions that we support.
 
 %h2 Bundler API Sponsors
 

--- a/source/v1.0/index.haml
+++ b/source/v1.0/index.haml
@@ -6,7 +6,7 @@
 
 .contents
   %ul.bullet
-    = link_to("Troubleshooting", "https://github.com/carlhuda/bundler/blob/1-0-stable/ISSUES.md")
+    = link_to("Troubleshooting", "https://github.com/bundler/bundler/blob/1-0-stable/ISSUES.md")
     = link_to("Understanding Bundler", "./rationale.html")
     = link_to("Gemfile Manual", "./man/gemfile.5.html")
     = link_to("CLI Manual", "./man/bundle.1.html")

--- a/source/v1.1/index.haml
+++ b/source/v1.1/index.haml
@@ -6,7 +6,7 @@
 
 .contents
   %ul.bullet
-    = link_to 'Troubleshooting', 'https://github.com/carlhuda/bundler/blob/1-0-stable/ISSUES.md'
+    = link_to 'Troubleshooting', 'https://github.com/bundler/bundler/blob/1-0-stable/ISSUES.md'
     = link_to 'Understanding Bundler', './rationale.html'
     = link_to 'Gemfile Manual', './man/gemfile.5.html'
     = link_to 'Command Line Reference', './commands.html'

--- a/source/v1.2/index.haml
+++ b/source/v1.2/index.haml
@@ -6,7 +6,7 @@
 %h2 Would you like to
 .buttons
   = link_to "Get started", "#getting-started"
-  = link_to "Report a bug", "https://github.com/carlhuda/bundler/blob/master/ISSUES.md"
+  = link_to "Report a bug", "https://github.com/bundler/bundler/blob/master/ISSUES.md"
   = link_to "See what's new", "/v1.2/whats_new.html"
   = link_to "Read documentation", "#use-bundler"
 
@@ -100,7 +100,7 @@
 %h2#get-involved Get involved
 %p Bundler has a lot of contributors and users, and they all talk to each other quite a bit. If you have questions, try the IRC channel or mailing list. If you're interested in contributing to the project (no programming skills needed), read the contributing guide. If you have sponsorship or security questions, email us directly.
 .buttons
-  = link_to "Contributing", "https://github.com/carlhuda/bundler/blob/master/CONTRIBUTE.md"
+  = link_to "Contributing", "https://github.com/bundler/bundler/blob/master/CONTRIBUTE.md"
   = link_to "Mailing list", "http://groups.google.com/group/ruby-bundler"
   = link_to "IRC channel", "irc://irc.freenode.net/#bundler"
   = link_to "Email core team", "mailto:andre.arko+terence.lee@gmail.com"

--- a/source/v1.2/whats_new.haml
+++ b/source/v1.2/whats_new.haml
@@ -4,7 +4,7 @@
   .bullet
     .description
       In this section, you'll find the major features introduced in the release. All the changes are documented in the Bundler 1.2 CHANGELOG.
-      = link_to 'CHANGELOG', 'https://github.com/carlhuda/bundler/blob/1-2-stable/CHANGELOG.md'
+      = link_to 'CHANGELOG', 'https://github.com/bundler/bundler/blob/1-2-stable/CHANGELOG.md'
 
 %h2#ruby-directive Specifying a Ruby Version
 

--- a/source/v1.3/whats_new.haml
+++ b/source/v1.3/whats_new.haml
@@ -4,7 +4,7 @@
   .bullet
     .description
       In this section, you'll find the major features introduced in the release. All the changes are documented in the Bundler 1.3 CHANGELOG.
-      = link_to 'CHANGELOG', 'https://github.com/carlhuda/bundler/blob/1-3-stable/CHANGELOG.md'
+      = link_to 'CHANGELOG', 'https://github.com/bundler/bundler/blob/1-3-stable/CHANGELOG.md'
 
 %h2#ruby-2 Compatible with Ruby 2 and Rubygems 2
 


### PR DESCRIPTION
The repository has moved from the carlhuda account to the bundler organization.

See also bundler/bundler#2500.
