### PR TITLE
Remove Deprecated Gem Sources

### DIFF
--- a/source/v1.3/gemfile.haml
+++ b/source/v1.3/gemfile.haml
@@ -15,8 +15,11 @@
       Gemfiles require at least one gem source, in the form of the URL for a Rubygems server.
       There are shortcuts for the default gem server, so all of these sources are the same.
     :highlight_ruby
+      source 'http://rubygems.org'
       source 'https://rubygems.org'
+      source 'http://gems.rubyforge.org'
       source 'https://gems.rubyforge.org'
+      source 'http://gemcutter.org'
       source 'https://gemcutter.org'
 
   .bullet


### PR DESCRIPTION
:rubygems, :rubyforge, :gemcutter symbols are deprecated because HTTP requests are insecure.
