### PR TITLE
Shorten the index page

### DIFF
--- a/source/index.haml
+++ b/source/index.haml
@@ -1,14 +1,15 @@
-%h2 What is Bundler?
-
-#intro
-  Bundler maintains a consistent environment for ruby applications. It tracks an application's code and the rubygems it needs to run, so that an application will always have the exact gems (and versions) that it needs to run.
-
-%h2 Would you like to
 .buttons
   = link_to 'Get started', '#getting-started'
   = link_to 'Report a bug', 'https://github.com/bundler/bundler/blob/master/ISSUES.md'
   = link_to "See what's new", '/v1.3/whats_new.html'
   = link_to 'Read documentation', '#use-bundler'
+
+%h2 What is Bundler?
+
+#intro
+  Bundler maintains a consistent environment for ruby applications. It tracks an application's code and the rubygems it needs to run, so that an application will always have the exact gems (and versions) that it needs to run.
+  %p
+  We designed bundler to make it easy to share your code across a number of development, staging and production machines. Of course, you know how to share your own application or gem: stick it on GitHub and clone it where you need it. Bundler makes it easy to make sure that your application has the dependencies it needs to start up and run without errors.
 
 %h2#getting-started
   Getting Started


### PR DESCRIPTION
It would be great for the index page to be just about what Bundler is. And links to get where you are going via the side bar and the top 4 button links.

I added a paragraph from the Bundlers Purpose and Rationale page to the index page.
