### PR TITLE
added bundle help to commands page and created bundle help page

### DIFF
--- a/source/shared/_whats_new.haml
+++ b/source/shared/_whats_new.haml
@@ -1,0 +1,6 @@
+%h1 What's New in each Release
+.buttons
+  = link_to 'Latest Version v1.3', '/v1.3/whats_new.html#version13'
+  = link_to 'v1.2', '/v1.2/whats_new.html#version12'
+  = link_to 'v1.1', 'https://github.com/bundler/bundler/blob/master/CHANGELOG.md#110-mar-7-2012'
+  = link_to 'v1.0', 'https://github.com/bundler/bundler/blob/master/CHANGELOG.md#100-august-29-2010'

--- a/source/v1.2/whats_new.haml
+++ b/source/v1.2/whats_new.haml
@@ -1,4 +1,6 @@
-%h2 What's New in v1.2
+= partial "shared/whats_new"
+
+%h2#version12 What's New in v1.2
 
 .contents
   .bullet

--- a/source/v1.3/bundle_help.haml
+++ b/source/v1.3/bundle_help.haml
@@ -1,0 +1,10 @@
+%h2 bundle help
+
+.contents
+  .bullet
+    .description
+      Displays detailed help for each subcommand on your command line
+    :highlight_plain
+      $ bundle help
+    .notes
+      #{ link_to 'View the same man pages here', '/v1.3/man/bundle.1.html'}

--- a/source/v1.3/commands.haml
+++ b/source/v1.3/commands.haml
@@ -30,6 +30,9 @@
       - command.desc   = 'Creates a skeleton for creating a rubygem'
       - command.option = 'bin or -b'
     = command_table_row do |command|
+      - command.name   = 'help'
+      - command.desc   = 'Displays detailed help for each subcommand'
+    = command_table_row do |command|
       - command.name   = 'init'
       - command.desc   = 'Generates a Gemfile into the current working directory'
       - command.option = 'gemspec'

--- a/source/v1.3/whats_new.haml
+++ b/source/v1.3/whats_new.haml
@@ -1,4 +1,6 @@
-%h2 What's New
+= partial "shared/whats_new"
+
+%h2#version13 What's New in v1.3
 
 .contents
   .bullet


### PR DESCRIPTION
link to man page for bundle help page

link inline with text rather than green button

corrected indenting of .sunburst, put all of text in button

text all on one line

text in the button displays on one line without changing the css. remove the .notes a addition

delete .textnote class, which is not doing anything

added buttons for each version release

added changelog link for v1.1 and v1.0

added  buttons to other releases for whats new 1.2 page

updated buttons to links

created whats new page for version 1.0

created whats new page for version 1.1

header link typo

button links directly to 1.0 and 1.1 version in the changelog

added partials

moved partial to correct directory

renamed partial filename
