### PR TITLE
add width size because firefox doesn't automatically and chrome does. bu...

### DIFF
--- a/source/stylesheets/application.sass
+++ b/source/stylesheets/application.sass
@@ -94,8 +94,10 @@ code
   text-align: left
 
   .buttons
+    width: 100%
     a
-      margin-left: 0
+      &:last-child
+        margin-left: 0
 
   h2
     font-size: 16px


### PR DESCRIPTION
...tton now looks the same on both browsers.

add left and right padding for green button on sidebar for firefox
