### PR TITLE
Update link to Rubygems version docs

### DIFF
--- a/source/v1.5/gemfile.haml
+++ b/source/v1.5/gemfile.haml
@@ -33,7 +33,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'Rubygems version specifiers', 'http://docs.rubygems.org/read/chapter/16#page74'
+    = link_to 'Rubygems version specifiers', 'http://guides.rubygems.org/patterns/#declaring_dependencies'
 
   .bullet
     .description


### PR DESCRIPTION
The current link redirects to http://guides.rubygems.org/#page74 which is meaningless. Without knowing precisely what it use to point to, this link seems most relevant.
