### PR TITLE
Remove 10px from the contributor avatar width to get proper rows of 3 in Firefox.

### DIFF
--- a/source/stylesheets/application.sass
+++ b/source/stylesheets/application.sass
@@ -351,7 +351,7 @@ pre
   float: left
   margin: 1em 0
   text-align: center
-  width: 240px
+  width: 230px
 
   &:last-child
     padding-right: 0


### PR DESCRIPTION
The 240px width causes the avatars to break into uneven rows in Firefox:

![screen shot 2014-03-29 at 11 53 48 am](https://cloud.githubusercontent.com/assets/270746/2559255/82be262e-b773-11e3-85ca-032e03cf92f5.png)

This change makes them look like this instead:

![screen shot 2014-03-29 at 11 55 16 am](https://cloud.githubusercontent.com/assets/270746/2559263/b2aefd9a-b773-11e3-8e1f-0c71afcadcad.png)
