### PR TITLE
Document config for HTTPs source credentials.

### DIFF
--- a/source/v1.6/gemfile.haml
+++ b/source/v1.6/gemfile.haml
@@ -19,17 +19,22 @@
 
   .bullet
     .description
-      To access private repositories, you can use <code>bundle config</code> to
-      set the username and password on a per-source basis.
+      Some gem sources require a username and password. Use
+      <code>bundle config</code> to set the username and password for any
+      sources that need it. The command must be run once on each computer that
+      will install the Gemfile, but this keeps the credentials from being stored
+      in plain text in version control.
     :code
       $ bundle config https://gems.example.com/ user:password
     .description
-      As an alternative, you can provide credentials directly in the source URL.
+      For some sources, like a company Gemfury account, it may be easier to
+      simply include the credentials in the Gemfile as part of the source URL.
     :code
       # lang: ruby
       source "https://user:password@gems.example.com"
     .description
-      Credentials provided in the source URL will take precedence.
+      Credentials in the source URL will take precedence over credentials set
+      using <code>config</code>.
   
   .bullet
     .description

--- a/source/v1.7/gemfile.haml
+++ b/source/v1.7/gemfile.haml
@@ -21,17 +21,22 @@
 
   .bullet
     .description
-      To access private repositories, you can use <code>bundle config</code> to
-      set the username and password on a per-source basis.
+      Some gem sources require a username and password. Use
+      <code>bundle config</code> to set the username and password for any
+      sources that need it. The command must be run once on each computer that
+      will install the Gemfile, but this keeps the credentials from being stored
+      in plain text in version control.
     :code
       $ bundle config https://gems.example.com/ user:password
     .description
-      As an alternative, you can provide credentials directly in the source URL.
+      For some sources, like a company Gemfury account, it may be easier to
+      simply include the credentials in the Gemfile as part of the source URL.
     :code
       # lang: ruby
       source "https://user:password@gems.example.com"
     .description
-      Credentials provided in the source URL will take precedence.
+      Credentials in the source URL will take precedence over credentials set
+      using <code>config</code>.
 
   .bullet
     .description


### PR DESCRIPTION
Looking over bundler/bundler#3119, I noticed that the documentation changes never made them to the site. Here they are. Thanks to @hwartig for the original changes to the man pages in bundler/bundler#3124.
