### PR TITLE
Fix div overflow on long code samples

### DIFF
--- a/source/v1.7/bundle_package.haml
+++ b/source/v1.7/bundle_package.haml
@@ -5,7 +5,8 @@
     .description
       Locks and then caches the gems into <code>./vendor/cache</code>.
     :code
-      $ bundle package [--all] [--gemfile=GEMFILE] [--no-install] [--no-prune] [--path=PATH] [--quiet]
+      $ bundle package [--all] [--gemfile=GEMFILE] [--no-install] [--no-prune]
+                       [--path=PATH] [--quiet]
     .notes
       %p
         Options:

--- a/source/v1.7/gemfile_ruby.haml
+++ b/source/v1.7/gemfile_ruby.haml
@@ -6,7 +6,8 @@
       Like gems, developers can setup a dependency on Ruby. This makes your app fail faster in case you depend on specific features in a Ruby VM. This way, the Ruby VM on your deployment server will match your local one. You can do this by using the <code>ruby</code> directive in the <code>Gemfile</code>:
     :code
       # lang: ruby
-      ruby 'RUBY_VERSION', :engine => 'ENGINE', :engine_version => 'ENGINE_VERSION', :patchlevel => 'RUBY_PATCHLEVEL'
+      ruby 'RUBY_VERSION', :engine => 'ENGINE', :engine_version => 'ENGINE_VERSION',
+        :patchlevel => 'RUBY_PATCHLEVEL'
 
   .bullet
     .description


### PR DESCRIPTION
I noticed a couple of places where code examples were overflowing. I've updated the markup here to flow to the next line, as is currently done for the bundle install documentation. Could also add an overflow-x style to pre elements, but it looks like existing preference is to have code sample split to additional lines. Thanks!

![ruby_version](https://cloud.githubusercontent.com/assets/1431823/4894199/6e1a69b4-63ce-11e4-9cdb-8ba9e8f05071.png)
![bundle_package](https://cloud.githubusercontent.com/assets/1431823/4894200/6e20bec2-63ce-11e4-89d4-56325d020fb7.png)
