### PR TITLE
Remove --no-install from bundle package 1.7 docs

### DIFF
--- a/source/v1.7/bundle_package.haml
+++ b/source/v1.7/bundle_package.haml
@@ -5,7 +5,7 @@
     .description
       Locks and then caches the gems into <code>./vendor/cache</code>.
     :code
-      $ bundle package [--all] [--gemfile=GEMFILE] [--no-install] [--no-prune]
+      $ bundle package [--all] [--gemfile=GEMFILE] [--no-prune]
                        [--path=PATH] [--quiet]
     .notes
       %p


### PR DESCRIPTION
Since it only exists in 1.8...
