### PR TITLE
Translation widget

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -103,6 +103,7 @@ helpers CommandReferenceHelper
 helpers ConfigHelper
 helpers DocsHelper
 helpers AvatarHelper
+helpers LanguageHelper
 
 activate :blog do |blog|
   blog.name = 'blog'

--- a/helpers/language_helper.rb
+++ b/helpers/language_helper.rb
@@ -2,6 +2,10 @@ module LanguageHelper
   LOCALES_DIR = 'locales'.freeze
   LOCALIZABLE_DIR = 'source/localizable/'.freeze
 
+  def current_page_languages_select
+    current_page_languages&.map { |k, v| [v, k] } || [%w(English en)]
+  end
+
   def current_page_languages
     return nil unless current_page_language
     path = current_path =~ /\A\w{2}\// ? current_page.path[3..-1] : current_page.path

--- a/helpers/language_helper.rb
+++ b/helpers/language_helper.rb
@@ -1,0 +1,44 @@
+module LanguageHelper
+  LOCALES_DIR = 'locales'.freeze
+  LOCALIZABLE_DIR = 'source/localizable/'.freeze
+
+  def current_page_languages
+    return nil unless current_page_language
+    path = current_path =~ /\A\w{2}\// ? current_page.path[3..-1] : current_page.path
+
+    current_page.path =~ /\.\w{2}\.html/ ? languages_per_filename(path) :
+      languages_from_locales(path)
+  end
+
+  def current_page_language
+    current_page.metadata.dig(:options, :locale)
+  end
+
+  private
+
+  def languages_from_locales(path)
+    dirname = File.dirname(path)
+    filename = File.basename(path, '.*')
+
+    return unless Dir["#{LOCALIZABLE_DIR}#{dirname}/#{filename}*"]
+
+    languages = Dir[File.join(LOCALES_DIR, '*.yml')].map do |file|
+      File.basename(file).gsub('.yml', '')
+    end
+
+    translated = languages.map { |lang| [lang, t("languages.#{lang}")] }.flatten
+    Hash[*translated]
+  end
+
+  def languages_per_filename(path)
+    dirname = File.dirname(path)
+    filename = File.basename(path, '.*')
+
+    matched = Dir["#{LOCALIZABLE_DIR}#{dirname}/*"].map do |f|
+      File.basename(f, '.*').match(/\A#{Regexp.escape(filename)}\.(\w{2})\./)
+    end.compact
+
+    translated = matched.map { |match| [match[1] => t("languages.#{match[1]}")] }
+    Hash[*translated]
+  end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   languages:
     en: English
-    pl: polski
+    pl: polski (Polish)
   home:
     bundler_info1: |
       Bundler provides a consistent environment for Ruby projects by tracking

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  languages:
+    en: English
+    pl: polski
   home:
     bundler_info1: |
       Bundler provides a consistent environment for Ruby projects by tracking
@@ -23,5 +26,9 @@ en:
     blog: "Blog"
     repository: "Repository"
     toggle_navigation: "Toggle navigation"
+    language_bar_html: |
+          Hi! We've guessed that your native language is <a href='#' id='language-link'></a>.
+          You can switch clicking <a href='#' id='language-link-static'>here</a>.
+    dismiss: "[dismiss]"
   search:
     placeholder: "Type to search..."

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,4 +1,7 @@
 //= require jquery
+//= require js.cookie
+//= require cookies_manager
+//= require translations_widget
 //= require bootstrap/transition
 //= require bootstrap/button
 //= require bootstrap/tooltip

--- a/source/javascripts/cookies_manager.js
+++ b/source/javascripts/cookies_manager.js
@@ -1,0 +1,37 @@
+'use strict';
+
+(function() {
+  var CookiesManager = window.CookiesManager = function() {
+    this.DISMISSED_KEY = 'dismissed';
+    this.LANGUAGE_KEY = 'language';
+    this.TRUE = 'true';
+  };
+
+  CookiesManager.prototype.set = function(name, value) {
+    return Cookies.set(name, value, { expires: 365*10 });
+  };
+
+  CookiesManager.prototype.remove = function(name)  {
+    return Cookies.remove(name);
+  };
+
+  CookiesManager.prototype.get = function(name)  {
+    return Cookies.get(name);
+  };
+
+  CookiesManager.prototype.setDismiss = function()  {
+    return this.set(this.DISMISSED_KEY, this.TRUE);
+  };
+
+  CookiesManager.prototype.isDismissed = function() {
+    return this.get(this.DISMISSED_KEY) === this.TRUE;
+  };
+
+  CookiesManager.prototype.choosenLanguage = function() {
+    return this.get(this.LANGUAGE_KEY);
+  };
+  
+  CookiesManager.prototype.setLanguage = function(language) {
+    return this.set(this.LANGUAGE_KEY, language);
+  };
+})();

--- a/source/javascripts/js.cookie.js
+++ b/source/javascripts/js.cookie.js
@@ -1,0 +1,151 @@
+/*!
+ * JavaScript Cookie v2.1.2
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+	} else if (typeof exports === 'object') {
+		module.exports = factory();
+	} else {
+		var OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				if (!converter.write) {
+					value = encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				} else {
+					value = converter.write(value, key);
+				}
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				return (document.cookie = [
+					key, '=', value,
+					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
+					attributes.path    && '; path=' + attributes.path,
+					attributes.domain  && '; domain=' + attributes.domain,
+					attributes.secure ? '; secure' : ''
+				].join(''));
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					var name = parts[0].replace(rdecode, decodeURIComponent);
+					cookie = converter.read ?
+						converter.read(cookie, name) : converter(cookie, name) ||
+						cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.set = api;
+		api.get = function (key) {
+			return api(key);
+		};
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));

--- a/source/javascripts/translations_widget.js
+++ b/source/javascripts/translations_widget.js
@@ -1,0 +1,104 @@
+'use strict';
+
+(function() {
+  var TranslationWidget = window.TranslationWidget = function()  {
+    this.TRANSLATIONS_BAR_ID = '#translations-bar';
+    this.LANGUAGE_LINK_ID = '#language-link';
+    this.LANGUAGE_LINK_STATIC_ID = '#language-link-static';
+    this.DISMISS_BUTTON_ID = '#translations-bar-close';
+    this.cookiesManager = new CookiesManager();
+    this.choosenLanguage = this.cookiesManager.choosenLanguage();
+
+    this.detectLanguage = function()  {
+      var lang = window.navigator.languages ? window.navigator.languages[0] : null;
+      lang = lang || window.navigator.language || window.navigator.browserLanguage || window.navigator.userLanguage;
+      if (lang.indexOf('-') !== -1) return lang.split('-')[0];
+      if (lang.indexOf('_') !== -1) return lang.split('_')[0];
+      return lang;
+    };
+
+    this.initElements = function() {
+      this.translationBar = $(this.TRANSLATIONS_BAR_ID);
+      this.link = $(this.LANGUAGE_LINK_ID);
+      this.staticLink = $(this.LANGUAGE_LINK_STATIC_ID);
+      this.dismissButton = $(this.DISMISS_BUTTON_ID);
+    };
+
+    this.initWidget = function()  {
+      this.setRedirectButtons();
+      this.initDismissButton();
+      this.translationBar.slideDown(1000);
+    };
+
+    this.initDismissButton = function() {
+      var self = this;
+
+      this.dismissButton.click(function(e)  {
+        e.preventDefault();
+        self.translationBar.slideUp(1000);
+        self.cookiesManager.setDismiss();
+      });
+    };
+
+    this.setRedirectButtons = function()  {
+      this.link.click(this.switchToLanguageAndSaveCookies.bind(this));
+      this.staticLink.click(this.switchToLanguageAndSaveCookies.bind(this));
+      this.link.text(LANGUAGES[this.browserLanguage]);
+    };
+
+    this.switchToLanguageAndSaveCookies = function(e)  {
+      e.preventDefault();
+      this.cookiesManager.setLanguage(this.browserLanguage);
+      window.location.href = this.languagePath();
+    };
+
+    this.languagePath = function()  {
+      return '/' + this.browserLanguage + location.pathname;
+    };
+
+    this.switchToLanguageUsingCookies = function()  {
+      window.location.href = this.languagePathFromCookies();
+    };
+
+    this.languagePathFromCookies = function() {
+      return '/' + this.cookiesManager.choosenLanguage() + location.pathname;
+    };
+
+    this.checkChoosenLanguage = function() {
+      return (this.choosenLanguage != null) && (CURRENT_LANGUAGE != this.choosenLanguage) &&
+        (this.choosenLanguage in LANGUAGES);
+    }
+  };
+
+  TranslationWidget.prototype.init = function()  {
+    if (CURRENT_LANGUAGE == null || CURRENT_LANGUAGE === '')  return;
+    if (LANGUAGES == null || LANGUAGES === '')  return;
+
+    // checks from cookies
+    if (this.cookiesManager.isDismissed()) return;
+
+    // language detection
+    this.browserLanguage = this.detectLanguage();
+    if (CURRENT_LANGUAGE === this.browserLanguage) return;
+    if (!(this.browserLanguage in LANGUAGES)) return;
+
+    this.initElements();
+    this.initWidget();
+  };
+
+  TranslationWidget.prototype.checkChoosenLanguageAndRedirect = function()  {
+    if (CURRENT_LANGUAGE == null || CURRENT_LANGUAGE === '')  return;
+    if (LANGUAGES == null || LANGUAGES === '')  return;
+
+    if (this.checkChoosenLanguage()) {
+      return this.switchToLanguageUsingCookies();
+    }
+  };
+})();
+
+window.translationWidget = new TranslationWidget();
+translationWidget.checkChoosenLanguageAndRedirect();
+
+$(document).ready(function()  {
+  translationWidget.init();
+});

--- a/source/javascripts/translations_widget.js
+++ b/source/javascripts/translations_widget.js
@@ -6,6 +6,8 @@
     this.LANGUAGE_LINK_ID = '#language-link';
     this.LANGUAGE_LINK_STATIC_ID = '#language-link-static';
     this.DISMISS_BUTTON_ID = '#translations-bar-close';
+    this.LANGUAGE_SELECT_ID = '#language-select';
+    this.LINK_REGEX = /^\/[a-zA-Z]{2}(\/.*)/;
     this.cookiesManager = new CookiesManager();
     this.choosenLanguage = this.cookiesManager.choosenLanguage();
 
@@ -53,7 +55,8 @@
     };
 
     this.languagePath = function()  {
-      return '/' + this.browserLanguage + location.pathname;
+      var language = (this.browserLanguage == 'en' ? '' : ('/' + this.browserLanguage));
+      return language + this.pathname();
     };
 
     this.switchToLanguageUsingCookies = function()  {
@@ -61,12 +64,18 @@
     };
 
     this.languagePathFromCookies = function() {
-      return '/' + this.cookiesManager.choosenLanguage() + location.pathname;
+      var language = (this.cookiesManager.choosenLanguage() == 'en' ? '' : ('/' + this.cookiesManager.choosenLanguage()));
+      return language + this.pathname();
     };
 
     this.checkChoosenLanguage = function() {
       return (this.choosenLanguage != null) && (CURRENT_LANGUAGE != this.choosenLanguage) &&
         (this.choosenLanguage in LANGUAGES);
+    };
+
+    this.pathname = function()  {
+      var url_without_language = location.pathname.match(this.LINK_REGEX);
+      return url_without_language != null ? url_without_language[1] : location.pathname;
     }
   };
 
@@ -94,11 +103,26 @@
       return this.switchToLanguageUsingCookies();
     }
   };
+
+  TranslationWidget.prototype.initLanguageSelect = function()  {
+    var self = this;
+    this.languageSelect = $(this.LANGUAGE_SELECT_ID);
+
+    this.languageSelect.change(function() {
+      var optionSelected = $(this).find("option:selected");
+      var valueSelected  = optionSelected.val();
+
+      self.cookiesManager.setDismiss();
+      self.cookiesManager.setLanguage(valueSelected);
+      self.switchToLanguageUsingCookies();
+    })
+  };
 })();
 
 window.translationWidget = new TranslationWidget();
 translationWidget.checkChoosenLanguageAndRedirect();
 
 $(document).ready(function()  {
+  translationWidget.initLanguageSelect();
   translationWidget.init();
 });

--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -5,3 +5,5 @@
       %li= link_to t('navbar.team'), "/contributors.html"
       %li= link_to t('navbar.blog'), "/blog"
       %li= link_to t('navbar.repository'), "https://github.com/bundler/bundler"
+
+      %form.navbar-form.pull-right.translation_select_height= select_tag :language, options: current_page_languages_select, selected: current_page_language, id: 'language-select', class: 'form-control'

--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -18,3 +18,9 @@
         %li= link_to t('navbar.docs'), '/docs.html'
         %li= link_to t('navbar.team'), '/contributors.html'
         %li= link_to t('navbar.blog'), '/blog'
+
+#translations-bar.row.bg-light-blue-no-padding.translate-bar-height{style: 'display: none'}
+  .container
+    .text-center
+      %span= t('navbar.language_bar_html').html_safe
+      %a#translations-bar-close{href: '#'}= t('navbar.dismiss').html_safe

--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -11,6 +11,10 @@
 
     = yield_content :head
 
+    :javascript
+      var CURRENT_LANGUAGE = '#{current_page_language}';
+      var LANGUAGES = #{current_page_languages.to_json};
+
     = javascript_include_tag "application"
     = javascript_include_tag "analytics", async: true
     = stylesheet_link_tag "application"

--- a/source/stylesheets/_navbar.scss
+++ b/source/stylesheets/_navbar.scss
@@ -9,3 +9,11 @@
 .navbar {
   margin-bottom: 0;
 }
+
+.select-height  {
+  height: 50px;
+}
+
+.translation_select_height {
+  line-height: 56px;
+}

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -64,6 +64,10 @@ $navbar-height: 50px;
   padding: 30px 2%;
 }
 
+.bg-light-blue-no-padding {
+  background-color: #DBEAF3;
+}
+
 .bg-dark-blue {
   background-color: #64C9EF;
   padding: 30px 2%;


### PR DESCRIPTION
![selection_277](https://cloud.githubusercontent.com/assets/3147506/16708393/79076a5e-45f2-11e6-96f3-c9dba6056026.png)

It works like that: (using cookies)
- row with suggested language will automatically show if there is different language selected in browser and this language is available
- if someone clicked [dismiss], this row will never again appear
- if someone clicks on language on row/change language in language selector, it will automatically redirect to page with correct language (when there is no such page, it will fallbacks to English)

I haven't found better place/look for language selector yet :/

It's based on redesign branch.
