### PR TITLE
Add meta tag for specifying language

### DIFF
--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -3,6 +3,7 @@
   %head
     %meta(charset="utf-8")
     %meta(http-equiv="X-UA-Compatible" content="IE=edge")
+    %meta(http-equiv="Content-Language" content="en")
     %meta(name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no")
     %meta(name="globalsign-domain-verification" content="276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL")
     %title


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

Chrome was suggesting to translate pages from Danish.

### What was your diagnosis of the problem?

The meta tag for specifying language was missing.

### What is your fix for the problem, implemented in this PR?

I added the missing meta tag.

### Why did you choose this fix out of the possible options?

I'm not aware about any other possible options.
