### PR TITLE
Fix the command for "Running your plugin locally"

### DIFF
--- a/source/v1.16/guides/bundler_plugins.html.haml
+++ b/source/v1.16/guides/bundler_plugins.html.haml
@@ -195,7 +195,7 @@ title: How to write a Bundler plugin
         6. Running your plugin locally
 
       %p
-        To install and run your plugin locally, you can run <code>bundler plugin install copycat --source file://PATH_TO_GEM</code>
+        To install and run your plugin locally, you can run <code>bundler plugin install --git '/PATH/TO/GEM' copycat</code>
 
       %h3#deploying_your_plugin
         7. Deploying your plugin

--- a/source/v1.17/guides/bundler_plugins.html.haml
+++ b/source/v1.17/guides/bundler_plugins.html.haml
@@ -195,7 +195,7 @@ title: How to write a Bundler plugin
         6. Running your plugin locally
 
       %p
-        To install and run your plugin locally, you can run <code>bundler plugin install copycat --source file://PATH_TO_GEM</code>
+        To install and run your plugin locally, you can run <code>bundler plugin install --git '/PATH/TO/GEM' copycat</code>
 
       %h3#deploying_your_plugin
         7. Deploying your plugin

--- a/source/v2.0/guides/bundler_plugins.html.haml
+++ b/source/v2.0/guides/bundler_plugins.html.haml
@@ -195,7 +195,7 @@ title: How to write a Bundler plugin
         6. Running your plugin locally
 
       %p
-        To install and run your plugin locally, you can run <code>bundler plugin install copycat --source file://PATH_TO_GEM</code>
+        To install and run your plugin locally, you can run <code>bundler plugin install --git '/PATH/TO/GEM' copycat</code>
 
       %h3#deploying_your_plugin
         7. Deploying your plugin

--- a/source/v2.1/guides/bundler_plugins.html.haml
+++ b/source/v2.1/guides/bundler_plugins.html.haml
@@ -209,7 +209,7 @@ title: How to write a Bundler plugin
         6. Running your plugin locally
 
       %p
-        To install and run your plugin locally, you can run <code>bundler plugin install copycat --source file://PATH_TO_GEM</code>
+        To install and run your plugin locally, you can run <code>bundler plugin install --git '/PATH/TO/GEM' copycat</code>
 
       %h3#deploying_your_plugin
         7. Deploying your plugin

--- a/source/v2.2/guides/bundler_plugins.html.haml
+++ b/source/v2.2/guides/bundler_plugins.html.haml
@@ -209,7 +209,7 @@ title: How to write a Bundler plugin
         6. Running your plugin locally
 
       %p
-        To install and run your plugin locally, you can run <code>bundler plugin install copycat --source file://PATH_TO_GEM</code>
+        To install and run your plugin locally, you can run <code>bundler plugin install --git '/PATH/TO/GEM' copycat</code>
 
       %h3#deploying_your_plugin
         7. Deploying your plugin


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The [instructions from Bundler's docs](https://bundler.io/v2.0/guides/bundler_plugins.html#running_your_plugin_locally) for `Running your plugin locally...` didn't work for me:

```
$ bundler plugin install my_plugin --source file://Users/me/Code/my_plugin/
Fetching source index from file://Users/me/Code/my_plugin/

Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from file://Users/me/Code/my_plugin/

Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from file://Users/me/Code/my_plugin/

Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from file://Users/me/Code/my_plugin/

Could not fetch specs from file://Users/me/Code/my_plugin/
```

[Here's an example](https://github.com/bundler/bundler/issues/5445#issuecomment-372154995) of someone else getting tripped up by this too.

### What was your diagnosis of the problem?

The `--source` flag doesn't seem to be the right flag, but `--git` works when you pass it a local git repository:

```
$ bundle plugin install --git '/Users/me/Code/my_plugin' my_plugin
Fetching /Users/me/Code/my_plugin
Resolving dependencies...
Using my_plugin 0.1.0 from /Users/me/Code/my_plugin (at master@34f3eb2)
Using bundler 2.0.1
Installed plugin my_plugin
```

### What is your fix for the problem, implemented in this PR?

Correct the docs.

### Why did you choose this fix out of the possible options?

So people aren't confused when they try developing a plugin locally. 

NB: In Version 2.1, looks like we'll have a [first-class --local-git option](https://github.com/bundler/bundler/pull/6749), so these docs might change in the 2.1 version.
