### PR TITLE
Clarify and deepen the discussion of Gemfile.lock in a gem repository

### DIFF
--- a/source/v2.0/guides/faq.html.haml
+++ b/source/v2.0/guides/faq.html.haml
@@ -219,6 +219,6 @@ title: Frequently Asked Questions
           <strong>A</strong>: To avoid the tradeoff between breaking `gem install` and breaking `bundle install`,
           one solution is to simply test both.  By keeping the `Gemfile.lock` in source control, it's possible to
           `bundle install` with and without the lockfile (by deleting it).
-  
+        %p
           To go a step further, running daily tests of `bundle install` without the lockfile is the most proactive
           solution to keeping the dependencies in working order.  This the approach taken by tools like Dependabot.

--- a/source/v2.0/guides/faq.html.haml
+++ b/source/v2.0/guides/faq.html.haml
@@ -181,12 +181,44 @@ title: Frequently Asked Questions
           <strong>Q</strong>: Should I commit my `Gemfile.lock` when writing a gem?
 
         %p
-          <strong>A</strong>: Yes. When Bundler first shipped, the
-          `Gemfile.lock` was gitignored inside gems.  Over time, however, it
-          became clear that this practice forces the pain of broken dependencies
-          onto new contributors, while leaving existing contributors potentially
-          unaware of the problem. Since `bundle install` is usually the first
-          step towards a contribution, the pain of broken dependencies would
-          discourage new contributors from contributing. As a result, we have
-          revised our guidance for gem authors to now recommend checking in the
-          lock for gems.
+          <strong>A</strong>: The answer depends on how you prefer to balance the experiences of your gem's
+          developers and its users. Broken dependencies occur externally to the development of a gem -- 
+          they can break even when the gem itself remains unchanged, typically because a new version of a 
+          dependency may fail to work with the gem.  Committing `Gemfile.lock` (or not)
+          will determine whether developer or users will be the first to discover these broken dependencies.
+          
+        %p
+          <strong>Q</strong>: What are the implications of committing my `Gemfile.lock` when writing a gem?
+
+        %p
+          <strong>A</strong>: The presence of a `Gemfile.lock` in a gem's repository ensures that 
+          a fresh checkout of the repository (e.g. by a new contributor) will complete its `bundle install`
+          successfully.  
+        %p
+          The disadvantage to committing `Gemfile.lock` means that it is the <i>users</i> of your gem who 
+          will be the first affected by broken dependencies -- their `gem install` may fail.
+        %p
+          When Bundler first shipped, the `Gemfile.lock` was `.gitignore`d inside gems.  For open source 
+          projects, this meant that `bundle install` could work when code was tested and merged, yet fail 
+          at a later point -- often when a new contributor was running `bundle install` for the first time;
+          the pain of these broken dependencies would tend to discourage them from contributing.  This by 
+          itself was significant enough that we've revised our guidance for gem authors to now recommend 
+          checking in the lock for gems.
+        %p
+          For private gems (implying a closed team in which the developers are all "maintainers"), having
+          broken dependencies in a development environment may be entirely appropriate -- a
+          `bundle install` would be initiated (either locally or as part of a build process) by someone 
+          prepared to fix any problems that arise.  In other words, the most proactive way to alert 
+          developers to broken dependencies is to remove the `Gemfile.lock` from the repository.
+          
+        %p
+          <strong>Q</strong>: In terms of Continuous Integration, what are the best practices for maintaining 
+          a repository that contains a gem?
+
+        %p
+          <strong>A</strong>: To avoid the tradeoff between breaking `gem install` and breaking `bundle install`,
+          one solution is to simply test both.  By keeping the `Gemfile.lock` in source control, it's possible to
+          `bundle install` with and without the lockfile (by deleting it).
+  
+          To go a step further, running daily tests of `bundle install` without the lockfile is the most proactive
+          solution to keeping the dependencies in working order.  This the approach taken by tools like Dependabot.

--- a/source/v2.0/guides/faq.html.haml
+++ b/source/v2.0/guides/faq.html.haml
@@ -181,11 +181,11 @@ title: Frequently Asked Questions
           <strong>Q</strong>: Should I commit my `Gemfile.lock` when writing a gem?
 
         %p
-          <strong>A</strong>: The answer depends on how you prefer to balance the experiences of your gem's
-          developers and its users. Broken dependencies occur externally to the development of a gem -- 
-          they can break even when the gem itself remains unchanged, typically because a new version of a 
-          dependency may fail to work with the gem.  Committing `Gemfile.lock` (or not)
-          will determine whether developer or users will be the first to discover these broken dependencies.
+          <strong>A</strong>: The answer depends on how you prefer to handle the problem of broken 
+          dependencies in your gem -- a situation that can occur externally to the development of a gem, 
+          even when the gem itself remains unchanged.  Gem developers and gem users encounter such
+          problems at different times, and the impact on each group depends in a large part on your
+          development workflow -- including whether you commit `Gemfile.lock`.
           
         %p
           <strong>Q</strong>: What are the implications of committing my `Gemfile.lock` when writing a gem?
@@ -195,8 +195,9 @@ title: Frequently Asked Questions
           a fresh checkout of the repository (e.g. by a new contributor) will complete its `bundle install`
           successfully.  
         %p
-          The disadvantage to committing `Gemfile.lock` means that it is the <i>users</i> of your gem who 
-          will be the first affected by broken dependencies -- their `gem install` may fail.
+          The consequence of committing `Gemfile.lock` is that the developers -- those in a position to 
+          resolve broken dependencies -- may be shielded from seeing the issue in the first place.  This
+          can be either good or bad.
         %p
           When Bundler first shipped, the `Gemfile.lock` was `.gitignore`d inside gems.  For open source 
           projects, this meant that `bundle install` could work when code was tested and merged, yet fail 
@@ -216,9 +217,12 @@ title: Frequently Asked Questions
           a repository that contains a gem?
 
         %p
-          <strong>A</strong>: To avoid the tradeoff between breaking `gem install` and breaking `bundle install`,
-          one solution is to simply test both.  By keeping the `Gemfile.lock` in source control, it's possible to
-          `bundle install` with and without the lockfile (by deleting it).
+          <strong>A</strong>: To avoid breaking both `gem install` and `bundle install`, one solution is to 
+          simply test both; by keeping the `Gemfile.lock` in source control, it's possible to
+          `bundle install` both with and without the lockfile (by deleting it).  If this is done as part of pull
+          request testing, new contributors may still find themselves facing the broken dependency problem -- but
+          with their first contribution, not their first checkout.
         %p
-          To go a step further, running daily tests of `bundle install` without the lockfile is the most proactive
-          solution to keeping the dependencies in working order.  This the approach taken by tools like Dependabot.
+          Thus, the best practice for accommodating both user and developer experiences is to configure the CI
+          for pull request testing to use `Gemfile.lock`, but run a separate set of <i>scheduled</i> CI builds 
+          without `Gemfile.lock` to test a clean `bundle install`.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The guidance on checking a `Gemfile.lock` into source control (for a gem library) has reversed in the past few years, but that's not due to a change in how the `Gemfile.lock` actually works.  So old articles about best practices (https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/) and new articles (https://bundler.io/v2.0/guides/faq.html#committing-lockfiles-in-libraries) are both technically correct.  


### What was your diagnosis of the problem?

The documentation on the Bundler site does a poor job of conveying the nuance of the issue.  This was discussed here:
https://github.com/bundler/bundler/issues/5879#issuecomment-551967102

### What is your fix for the problem, implemented in this PR?

This patch updates the documentation from saying "do this one thing" to explaining the pros and cons of committing a Gemfile.lock to source control.  It also does a better job of explaining the problem to be solved: the tendency of new versions of dependencies to break `bundle install` independently of changes to the actual gem.

### Why did you choose this fix out of the possible options?

I chose this fix because what works for open-source gems may not be best for privately-maintained gems, and the tooling that each project uses in its development workflow may be different.
