### PR TITLE
Fix canonical linking

### DIFF
--- a/source/layouts/commands_layout.haml
+++ b/source/layouts/commands_layout.haml
@@ -1,4 +1,4 @@
-- if /v(.*?)\/(man|bundle_(.*?))\//.match(current_page.destination_path)
+- if /v\d\.\d+\//.match(current_page.destination_path)
   - content_for(:canonical, commands_toplevel_path(current_page.destination_path))
 
 ~ wrap_layout :base do

--- a/source/layouts/md_guides_layout.haml
+++ b/source/layouts/md_guides_layout.haml
@@ -1,5 +1,8 @@
 - v = current_page.url.scan(/v\d\.\d+/).first || current_version
 
+- if /v\d\.\d+\//.match(current_page.destination_path)
+  - content_for(:canonical, commands_toplevel_path(current_page.destination_path))
+
 ~ wrap_layout :base do
   - content_for :tail do
     .row.bg-light-blue


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that Google is showing bundler docs for old versions in search results. An example of this problem is pointed out by @indirect in the 3rd bullet point of https://github.com/rubygems/bundler/pull/7591#discussion_r369845718.

### What was your diagnosis of the problem?

My diagnosis was that we already have a solution for this, namely, consider the latest version of each page as the canonical version.

The problem, I think, is that the regexp for adding the canonical link was incorrect for the kind of pages referenced by @indirect.

### What is your fix for the problem, implemented in this PR?

My fix is to use a proper regexp that includes all the pages where we want to do this. While fixing it, I also noticed other pages where we also want to do this that were using a different layout.

### Why did you choose this fix out of the possible options?

I chose this fix because it should improve our docs visibility in search results.