### PR TITLE
Update repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # bundler.io
-bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/bundler/bundler) gem.
+bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/rubygems/rubygems) gem.
 
 The site bundler.io is a static site generated using [Middleman](http://middlemanapp.com/).
 
-[Bundler's manual pages](https://github.com/bundler/bundler/tree/master/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
+[Bundler's manual pages](https://github.com/rubygems/rubygems/tree/master/bundler/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
 
 ## Development Set Up
 

--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -18,4 +18,4 @@
         %li= link_to t('navbar.docs'), '/docs.html'
         %li= link_to t('navbar.team'), '/contributors.html'
         %li= link_to t('navbar.blog'), '/blog'
-        %li= link_to t('navbar.repository'), "https://github.com/bundler/bundler"
+        %li= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems', target: '_blank', rel: 'noopener noreferrer'


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the links at the Bundler site were pointing only to the [legacy Bundler repository](https://github.com/rubygems/bundler).

### What is your fix for the problem, implemented in this PR?

- [x] I updated the links in the README.md file.

- [x] I replaced the repository link at the navbar with a dropdown that contains links to both the current and the legacy repositories as shown below:

<img width="1281" alt="Screen Shot 2020-03-29 at 10 25 51 PM" src="https://user-images.githubusercontent.com/47565678/77873928-f2fe0b80-7210-11ea-8a85-f5c39cbfea8d.png">

Responsive design is supported as well:

<img width="1281" alt="Screen Shot 2020-03-29 at 10 28 11 PM (2)" src="https://user-images.githubusercontent.com/47565678/77873992-2d67a880-7211-11ea-92b1-21961831067a.png">

Thanks for your support and guidance.

Best regards,

David Auza