### PR TITLE
Add data/known_plugins.yml and its Rake task

### DIFF
--- a/data/known_plugins.yml
+++ b/data/known_plugins.yml
@@ -1,0 +1,21 @@
+---
+- :name: bundler-changelogs
+  :uri: https://github.com/jdar/bundler-changelogs
+- :name: bundler-console
+  :uri: https://github.com/kddeisz/bundler-console
+- :name: bundler-dependency_graph
+  :uri: https://github.com/kerrizor/bundler-dependency_graph
+- :name: bundler-ecology
+  :uri: https://github.com/eco-rb/bundler-ecology
+- :name: bundler-explain
+  :uri: https://github.com/jhawthorn/bundler-explain
+- :name: bundler-inject
+  :uri: https://github.com/ManageIQ/bundler-inject
+- :name: bundler-licensed
+  :uri: https://github.com/sergey-alekseev/bundler-licensed
+- :name: bundler-private_install
+  :uri: https://github.com/fphilipe/bundler-private_install
+- :name: bundler-source-aws-s3
+  :uri: https://github.com/eki/bundler-source-aws-s3
+- :name: bundler-symlink
+  :uri: https://github.com/petekinnecom/bundler-symlink

--- a/lib/tasks/regenerate_known_plugins_yml.rake
+++ b/lib/tasks/regenerate_known_plugins_yml.rake
@@ -1,0 +1,91 @@
+desc "Recreate data/known_plugins.yml from RubyGems.org data. " \
+  "Look for gems with bundler- prefix names, and get their information, " \
+  "skipping invalid gems. Run with RUBYOPT=-W1 enabled to see diagnostic " \
+  "output about data not found. Uses curl, grep."
+task :regenerate_known_plugins_yml do
+  require 'yaml'
+
+  names_content = `curl --silent https://index.rubygems.org/names | grep '^bundler-'`
+  all_plugin_names = names_content.lines.map(&:chomp)
+
+  skipped_gem_names = %w[
+    bundler-add functionality-exists-in-bundler-now
+    bundler-auto-update
+    bundler-bootstrap empty
+    bundler-budit not-authoritative
+    bundler-changelog empty
+    bundler-fastupdate
+    bundler-fu
+    bundler-gem-hg
+    bundler-geminabox
+    bundler-gem_version_tasks
+    bundler-github functionality-exists-in-bundler-now
+    bundler-bouncer
+    bundler-interactive source-does-not-exist yanked-all-but-last
+    bundler-maglev-
+    bundler-next
+    bundler-norelease
+    bundler-pgs
+    bundler-prehistoric
+    bundler-sass
+    bundler-turbo
+    bundler-updater
+  ]
+  not_plugins = %w[
+    bundler-audit
+    bundler-audited_update
+    bundler-audit-ng
+    bundler-advise
+    bundler-bower
+    bundler-commentator
+    bundler-dependencies
+    bundler-diff
+    bundler-fixture
+    bundler-grep
+    bundler-gtags
+    bundler-leak
+    bundler-native-gems
+    bundler-organization_audit
+    bundler-patch
+    bundler-reorganizer
+    bundler-security
+    bundler-squash
+    bundler-stats
+    bundler-update_stdout
+    bundler-talks
+    bundler-unload
+    bundler-verbose
+  ]
+  # Suspected:
+  # bundler-fastupdate
+  plugin_names = all_plugin_names - skipped_gem_names - not_plugins
+
+  # https://guides.rubygems.org/rubygems-org-api/#gem-methods
+  # /api/v1/gems/[GEM NAME].(json|yaml)
+  # Example: https://rubygems.org/api/v1/gems/rails.json
+  plugins = plugin_names.map do |gem_name|
+    json_string = `curl --silent https://rubygems.org/api/v1/gems/#{gem_name}.json`
+    next "<#{gem_name.inspect} is unknown by the API>" if json_string == 'This rubygem could not be found.'
+
+    gem_info = JSON.parse(json_string)
+
+    uri = if gem_info["homepage_uri"].to_s == ""
+      gem_info["project_uri"]
+    else
+      gem_info["homepage_uri"]
+    end
+
+    {
+      name: gem_name,
+      uri: uri
+    }
+  end
+  # RUBYOPT=-W1 will display this diagnostic output
+  warn plugins.reject { |e| e.is_a?(Hash) }.inspect
+
+  valid_plugins = plugins.select { |e| e.is_a?(Hash) }
+
+  File.write(File.expand_path('../../data/known_plugins.yml', __dir__), YAML.dump(valid_plugins))
+  puts "Saved #{valid_plugins.size} plugins as data/known_plugins.yml"
+  puts "Done."
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

See #505 - there is no **Known Plugins** page in the site. Users have no way of discovering the community's Plugins for Bundler.

### What was your diagnosis of the problem?

#505 calls for a regeneratable YAML data-set for Middleman, kept up-to-date with a Rake task.

The generated YAML file could be checked in to git. (The Issue calls for this, too.)

❓ **Wondering:**
Most of the gems named with a prefix `bundler-` are not using the `plugins.rb` way of extending Bundler, but the "add a CLI command" way.

This PR currently adds data for `plugins.rb`-using gems, only. I'm wondering if you think I should add fewer skips.

### What is your fix for the problem, implemented in this PR?

This PR adds a YAML file from which it's easy to add a page. Compare to the Contributors page. Note: this PR does not include adding a page, only fetching the data for one.

My fix was "use some curl and grep" from the existing Issues, wrap that in a Rake task, and add a lot of ignored gem names.

#### TODO

- [x] Go through each of the elements in the generated YAML and check for a `plugins.rb` being there

### Why did you choose this fix out of the possible options?

I chose this fix because I noted that the data/ directory was already there, and that we are tending this data ourselves. We can tend another set of data, too. Esp. with explicit skips.
