### PR TITLE
chore: Refer to rubygems GitHub Organisation, not bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The site bundler.io is a static site generated using [Middleman](http://middlema
 
 Begin by cloning the repository onto your location machine:
 
-    git clone https://github.com/bundler/bundler-site.git
+    git clone https://github.com/rubygems/bundler-site.git
 
 Once complete prepare the dependencies by running:
 

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -14,14 +14,16 @@ module DocsHelper
     path = current_page.file_descriptor.relative_path.to_s
     repo = 
       if path.start_with?('doc/')
-        'bundler/bundler'
+        path = "bundler/#{path}"
+        'rubygems/rubygems'
       elsif path =~ %r{\Av\d+\.\d+/man/(bundle[_-]|gemfile)}
         path = "#{strip_version_from_url(path)}.ronn"
         path.sub!(/\.\d+\.ronn\z/, '.ronn') unless path.end_with?("gemfile.5.ronn")
-        'bundler/bundler'
+        path = "bundler/#{path}"
+        'rubygems/rubygems'
       else
         path = File.join 'source', path
-        'bundler/bundler-site'
+        'rubygems/bundler-site'
       end
     url = "https://github.com/#{repo}/blob/master/#{path}"
     

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -8,7 +8,7 @@ task :release => [:build, :update_site] do
     File.write("CNAME", "bundler.io")
 
     sh "git add -A ."
-    sh "git commit -m 'bundler/bundler-site@#{commit}'"
+    sh "git commit -m 'rubygems/bundler-site@#{commit}'"
 
     Bundler.with_clean_env do
       puts <<-TWO_FACTOR_WARNING

--- a/lib/tasks/travis/deploy.rake
+++ b/lib/tasks/travis/deploy.rake
@@ -35,7 +35,7 @@ namespace :travis do
       sh "git config user.name 'Travis CI'"
       sh "git config user.email '#{commit_author_email}'"
 
-      sh "git commit -m 'bundler/bundler-site@#{commit}'"
+      sh "git commit -m 'rubygems/bundler-site@#{commit}'"
       sh "git push origin master"
     end
 

--- a/source/blog/2016-07-10-bundler-1-13-and-redesigned-bundler-io.html.markdown
+++ b/source/blog/2016-07-10-bundler-1-13-and-redesigned-bundler-io.html.markdown
@@ -17,7 +17,7 @@ There are also two new guides to go with the new website: [Using Bundler In Appl
 The new site also includes some more improvements:
 
 * Command pages are now built from the Bundler repository instead of hand-written (where possible)
-* Commits to the master branch of [bundler-site](https://github.com/bundler/bundler-site) are now auto-deployed (via Travis)
+* Commits to the master branch of [bundler-site](https://github.com/rubygems/bundler-site) are now auto-deployed (via Travis)
 * Middleman has been updated to latest version
 * Every header in the guides and commands pages now has anchor links for navigation and reference
 * The site now supports multiple translations (although no translations have been completed yet)

--- a/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -442,4 +442,4 @@ Please include:
 ### Contributing to this guide
 [contributing-to-guide]: #contributing-to-this-guide
 
-If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/bundler/bundler-site/blob/master/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!
+If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/rubygems/bundler-site/blob/master/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!

--- a/source/v1.17/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/v1.17/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -442,4 +442,4 @@ Please include:
 ### Contributing to this guide
 [contributing-to-guide]: #contributing-to-this-guide
 
-If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/bundler/bundler-site/blob/master/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!
+If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/rubygems/bundler-site/blob/master/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!

--- a/source/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -442,4 +442,4 @@ Please include:
 ### Contributing to this guide
 [contributing-to-guide]: #contributing-to-this-guide
 
-If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/bundler/bundler-site/blob/master/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!
+If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/rubygems/bundler-site/blob/master/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

While investigating a Heroku deploy problem, I noted that the Travis deploy script and other things refer to the previous GitHub Organisation.

Example of Git output:
https://travis-ci.org/github/rubygems/bundler-site/builds/672651835#L2986

```
git add -A .
git config user.name 'Travis CI'
git config user.email '[secure]'
git commit -m 'bundler/bundler-site@d5ae0760c9f18f91ee4589291fe0398f0fe82f0b'
[master f9ca89d8] bundler/bundler-site@d5ae0760c9f18f91ee4589291fe0398f0fe82f0b
 2 files changed, 7 insertions(+), 7 deletions(-)
git push origin master
remote: This repository moved. Please use the new location:        
remote:   git@github.com:rubygems/bundler.github.io.git        
To github.com:bundler/bundler.github.io
   efb71573..f9ca89d8  master -> master
```

This repo has been moved to the `rubygems` Organisation from its start in the `bundler` Organisation.

### What was your diagnosis of the problem?

My diagnosis was that since the repo moved, warnings and slight inconsistencies exist.

We can update our tools to point to the new place.

### What is your fix for the problem, implemented in this PR?

My fix was to refer to the new location of the repo, to avoid the warnings emitted.

### Why did you choose this fix out of the possible options?

I chose this fix because I want to let the warnings guide me
