### PR TITLE
chore: Update Gemfile.lock to reflect Ruby 2.6.6p146

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ DEPENDENCIES
   travis
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.6p146
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was as a developer, I'd get a change in the Gemfile after `bundle install`.

### What was your diagnosis of the problem?

My diagnosis was that this could be a problem for the bundle install `--deployment` flag, which forbids changes to the lockfile on installing.

A recent update to the Ruby version used made this change necessary. See #509

### What is your fix for the problem, implemented in this PR?

My fix was to check in the current version of the lockfile.

### Why did you choose this fix out of the possible options?

I chose this fix because I couldn't come up with any alternative.
