### PR TITLE
Git Sources shorthands: Deprecation note

### DIFF
--- a/source/v2.0/guides/git.html.haml
+++ b/source/v2.0/guides/git.html.haml
@@ -86,6 +86,8 @@ title: How to install gems from git repositories
         gem 'rugged', git: 'git://github.com/libgit2/rugged.git', submodules: true
     .bullet
       .description
+        (<b>NB</b>: These built-in shorthand git sources are deprecated and will be
+        removed in Bundler 3.)
         If you are getting your gems from a public GitHub repository,
         you can use the shorthand
       :code

--- a/source/v2.0/guides/git.html.haml
+++ b/source/v2.0/guides/git.html.haml
@@ -87,7 +87,8 @@ title: How to install gems from git repositories
     .bullet
       .description
         (<b>NB</b>: These built-in shorthand git sources are deprecated and will be
-        removed in Bundler 3.)
+        removed in Bundler 3. Instead of these, we encourage you to use <em>Custom
+        git sources</em> in your Gemfile.)
         If you are getting your gems from a public GitHub repository,
         you can use the shorthand
       :code


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the deprecated status of the built-in shorthands was not documented.

Fixes #503

### What was your diagnosis of the problem?

My diagnosis was that @duckinator was right about the way to deal with the shorthands in the documentation.

### What is your fix for the problem, implemented in this PR?

My fix was to **document the deprecation**  (v2.0/ directory) with a *NB* marker.

**Update**: Added "what to do" as a suggestion.

### Why did you choose this fix out of the possible options?

I chose this fix because I didn't know about any special tricks to show "All This Section Is Deprecated".
