### PR TITLE
Update bundle config syntax to non-deprecated version

### DIFF
--- a/source/v2.0/guides/git.html.haml
+++ b/source/v2.0/guides/git.html.haml
@@ -148,12 +148,12 @@ title: How to install gems from git repositories
         instead of using the remote version. This can be achieved by setting
         up a local override:
       :code
-        $ bundle config local.GEM_NAME /path/to/local/git/repository
+        $ bundle config set local.GEM_NAME /path/to/local/git/repository
     .bullet
       .description
         For example, in order to use a local Rack repository, a developer could call:
       :code
-        $ bundle config local.rack ~/Work/git/rack
+        $ bundle config set local.rack ~/Work/git/rack
       .description
         and setup the git repo pointing to a branch:
       :code

--- a/source/v2.0/guides/git.html.haml
+++ b/source/v2.0/guides/git.html.haml
@@ -189,4 +189,4 @@ title: How to install gems from git repositories
       .description
         %p If you do not want bundler to make these branch checks, you can override it by setting this option:
       :code
-        $ bundle config disable_local_branch_check true
+        $ bundle config set disable_local_branch_check true


### PR DESCRIPTION
[DEPRECATED] Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set local.gem_name /foo/bar/baz.git` instead.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that docs are out of sync with the current version of bundler.

### What was your diagnosis of the problem?

Running the commands as given in the README gives a deprecation error.

### What is your fix for the problem, implemented in this PR?

Update the docs

### Why did you choose this fix out of the possible options?

It is good.
