### PR TITLE
Adjust example Gemfile to best practices

### DIFF
--- a/source/v2.1/gemfile.html.haml
+++ b/source/v2.1/gemfile.html.haml
@@ -16,11 +16,20 @@
         Gemfiles require at least one gem source, in the form of the URL for a RubyGems server. Generate a Gemfile with the default rubygems.org source by running <code>bundle init</code>. If you can, use <code>https</code> so your connection to the rubygems.org server will be verified with SSL.
       :code
         # lang: ruby
-        source 'https://rubygems.org' do
-          # Gems here
-        end
+        source 'https://rubygems.org'
+
+        # Gems here
       .notes
-        Global source lines are a security risk and should not be used as they can lead to gems being installed from unintended sources.
+        If you want to pick up gems from a different source, make sure to wrap the extra sources in a block. Multiple global source lines are a security risk and should not be used as they can lead to gems being installed from unintended sources.
+      :code
+        # lang: ruby
+        source 'https://rubygems.org'
+
+        # Gems here
+
+        source 'https://gems.example.com' do
+          # Gems from the alternative source here
+        end
 
     .bullet
       .description


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

I saw the example `Gemfile` on the main website, which uses a global `source` command, clicked on "Learn more", just to learn that global `source` commands are strongly discouraged for good reasons.

### What was your diagnosis of the problem?

The main website violated best practices, so it probably hasn't received much attention over the last weeks or months.

### What is your fix for the problem, implemented in this PR?

Adjust the example to the best practices.

### Why did you choose this fix out of the possible options?

The alternative would be to change the recommendation on the Gemfile description site, but the reasons provided for discouraging global `source` commands are very convincing.
