### PR TITLE
Update navbar Repository link to bundler

### DIFF
--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -4,4 +4,4 @@
       %li= link_to t('navbar.docs'), "/docs.html"
       %li= link_to t('navbar.team'), "/contributors.html"
       %li= link_to t('navbar.blog'), "/blog"
-      %li= link_to t('navbar.repository'), "https://github.com/rubygems/rubygems/bundler"
+      %li= link_to t('navbar.repository'), "https://github.com/rubygems/rubygems/tree/master/bundler"

--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -4,4 +4,4 @@
       %li= link_to t('navbar.docs'), "/docs.html"
       %li= link_to t('navbar.team'), "/contributors.html"
       %li= link_to t('navbar.blog'), "/blog"
-      %li= link_to t('navbar.repository'), "https://github.com/rubygems/bundler"
+      %li= link_to t('navbar.repository'), "https://github.com/rubygems/rubygems/bundler"

--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -4,4 +4,4 @@
       %li= link_to t('navbar.docs'), "/docs.html"
       %li= link_to t('navbar.team'), "/contributors.html"
       %li= link_to t('navbar.blog'), "/blog"
-      %li= link_to t('navbar.repository'), "https://github.com/bundler/bundler"
+      %li= link_to t('navbar.repository'), "https://github.com/rubygems/bundler"

--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -18,4 +18,4 @@
         %li= link_to t('navbar.docs'), '/docs.html'
         %li= link_to t('navbar.team'), '/contributors.html'
         %li= link_to t('navbar.blog'), '/blog'
-        %li= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems/bundler', target: '_blank', rel: 'noopener noreferrer'
+        %li= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems/tree/master/bundler', target: '_blank', rel: 'noopener noreferrer'

--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -18,4 +18,4 @@
         %li= link_to t('navbar.docs'), '/docs.html'
         %li= link_to t('navbar.team'), '/contributors.html'
         %li= link_to t('navbar.blog'), '/blog'
-        %li= link_to t('navbar.repository'), 'https://github.com/rubygems/bundler', target: '_blank', rel: 'noopener noreferrer'
+        %li= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems/bundler', target: '_blank', rel: 'noopener noreferrer'

--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -18,4 +18,4 @@
         %li= link_to t('navbar.docs'), '/docs.html'
         %li= link_to t('navbar.team'), '/contributors.html'
         %li= link_to t('navbar.blog'), '/blog'
-        %li= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems', target: '_blank', rel: 'noopener noreferrer'
+        %li= link_to t('navbar.repository'), 'https://github.com/rubygems/bundler', target: '_blank', rel: 'noopener noreferrer'


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was trying to navigate to the bundler via the "Repository" link in the https://bundler.io/ navbar. 

### What was your diagnosis of the problem?

My diagnosis was the link was incorrect in the navbar, as it was correct in the footer.

### What is your fix for the problem, implemented in this PR?

My fix is to update the link, as well as update the footer to the new `rubygems/bundler` home.

### Why did you choose this fix out of the possible options?

I chose this fix because I think the users want to go to the bundler github site, not the rubygems site, from https://bundler.io/