### PR TITLE
Highlighted a key precondition to use the Local Git Repository feature.

### DIFF
--- a/source/v2.0/guides/git.html.haml
+++ b/source/v2.0/guides/git.html.haml
@@ -172,9 +172,10 @@ title: How to install gems from git repositories
           you may point to a commit that only exists in your local machine.
 
         %p
+          <strong>Please note!</strong>
           Bundler does many checks to ensure a developer won't work with
-          invalid references. Particularly, we force a developer to specify
-          a branch in the <code>Gemfile</code> in order to use this feature. If the branch
+          invalid references. Particularly, <strong>we force a developer to specify
+          a branch in the <code>Gemfile</code> in order to use this feature</strong>. If the branch
           specified in the <code>Gemfile</code> and the current branch in the local git
           repository do not match, Bundler will abort. This ensures that
           a developer is always working against the correct branches, and prevents


### PR DESCRIPTION
The problem was that I couldn't easily glean a key precondition to using the Local Git Repository feature, which resulted in spending several minutes trying to use the feature before realizing that I was doing it incorrectly.

My diagnosis was that a key piece of information was buried a few paragraphs down and difficult to spot until I read the documentation a few times.

My fix draws the reader's attention to this key piece of information.

I chose this fix because it seems like the smallest change to the existing documentation that could possibly provide value to the reader, helping them avoid my mistake.
