### PR TITLE
Catch up with man page naming change in main rubygems/rubygems repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: bundler
 rvm:
   - 2.6.6
 install:
+  - gem install bundler:2.1.4
   - bundle install --deployment
   - eval "$(ssh-agent -s)"
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,4 +234,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -18,7 +18,6 @@ module DocsHelper
         'rubygems/rubygems'
       elsif path =~ %r{\Av\d+\.\d+/man/(bundle[_-]|gemfile)}
         path = "#{strip_version_from_url(path)}.ronn"
-        path.sub!(/\.\d+\.ronn\z/, '.ronn') unless path.end_with?("gemfile.5.ronn")
         path = "bundler/#{path}"
         'rubygems/rubygems'
       else

--- a/source/partials/_commands_sidebar.haml
+++ b/source/partials/_commands_sidebar.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 %h4 Choose version
 .form-group

--- a/source/v1.12/deploying.html.md
+++ b/source/v1.12/deploying.html.md
@@ -31,7 +31,7 @@ with the exact same gems you use in development.
 If you have run <code>bundle package</code>, the cached
 gems will be used automatically.
 
-<a href="/man/bundle-package.1.html" class="btn btn-primary">Learn More: Packing</a>
+<a href="/man/bundle-cache.1.html" class="btn btn-primary">Learn More: Packing</a>
 
 ### Automatic deployment with Capistrano
 

--- a/source/v1.12/docs.html.haml
+++ b/source/v1.12/docs.html.haml
@@ -3,7 +3,7 @@ title: Docs
 description: Main Docs page with all available resources
 ---
 
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v1.13/deploying.html.haml
+++ b/source/v1.13/deploying.html.haml
@@ -32,7 +32,7 @@
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-cache.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano

--- a/source/v1.13/docs.html.haml
+++ b/source/v1.13/docs.html.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v1.14/deploying.html.haml
+++ b/source/v1.14/deploying.html.haml
@@ -32,7 +32,7 @@
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-cache.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano

--- a/source/v1.14/docs.html.haml
+++ b/source/v1.14/docs.html.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v1.15/docs.html.haml
+++ b/source/v1.15/docs.html.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v1.15/guides/deploying.html.haml
+++ b/source/v1.15/guides/deploying.html.haml
@@ -35,7 +35,7 @@ title: Deploying with Bundler
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-cache.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano

--- a/source/v1.16/docs.html.haml
+++ b/source/v1.16/docs.html.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v1.16/guides/deploying.html.haml
+++ b/source/v1.16/guides/deploying.html.haml
@@ -35,7 +35,7 @@ title: How to deploy bundled applications
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-cache.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano

--- a/source/v1.17/docs.html.haml
+++ b/source/v1.17/docs.html.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v1.17/guides/deploying.html.haml
+++ b/source/v1.17/guides/deploying.html.haml
@@ -35,7 +35,7 @@ title: How to deploy bundled applications
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-cache.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano

--- a/source/v2.0/docs.html.haml
+++ b/source/v2.0/docs.html.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v2.0/guides/deploying.html.haml
+++ b/source/v2.0/guides/deploying.html.haml
@@ -35,7 +35,7 @@ title: How to deploy bundled applications
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-cache.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano

--- a/source/v2.1/docs.html.haml
+++ b/source/v2.1/docs.html.haml
@@ -1,4 +1,4 @@
-- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-package.1 bundle-exec.1 bundle-config.1 bundle_help)
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 .row.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',

--- a/source/v2.1/guides/deploying.html.haml
+++ b/source/v2.1/guides/deploying.html.haml
@@ -35,7 +35,7 @@ title: How to deploy bundled applications
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-cache.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano


### PR DESCRIPTION
In https://github.com/rubygems/rubygems/pull/3921, in order to be able to remove txt versions on man pages, the ronn sources are being renamed to keep the man section in their name. So, before they'd be named `bundle-<command>.ronn`, and now they are named `bundle-<command>.1.ronn`.

This PR changes the documentation site to catch up with that change.

While at it, I also updated the "BUNDLED WITH" section in the lockfile and also fixed some broken links pointing to `bundle-package` man pages, that are now `bundle-cache`