### PR TITLE
Copy the latest command references to top-level

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -63,21 +63,21 @@ Dir.glob("./source/localizable/#{config[:current_version]}/**/*").select{ |f| Fi
   proxy "#{country}/#{proxy_path}", page_path, locale: country.to_sym
   proxy proxy_path, page_path, locale: :en if country == 'en'
 end
+# Same for man-generated documentation
+# Ex: /v2.1/man/bundle-config.1.html.erb (adapted from bundler/bundler) available at /bundle_config.html
+Dir.glob("./source/#{config[:current_version]}/man/**/*").select{ |f| File.file?(f) }.each do |file_path|
+  handle_man_page(file_path) do |man_page_name, page_path|
+    proxy "/#{man_page_name}.html", page_path unless man_page_exists?(man_page_name, config[:current_version])
+  end
+end
 
 # Proxy man generated documentation to be available at /vX.XX/ (for compatibility with old guides)
-# Ex: /v1.12/man/bundle-install.1.html.erb available at /v1.12/bundle_install.html
+# Ex: /v1.12/man/bundle-install.1.html.erb (adapted from bundler/bundler) available at /v1.12/bundle_install.html
 config[:versions].each do |version|
   Dir.glob("./source/#{version}/man/**/*").select{ |f| File.file?(f) }.each do |file_path|
-    file_path = file_path[0..-5]
-    page_path = file_path.sub(/^\.\/source/, '')
-
-    man_page_name_matched = file_path.match(/man\/(.*)\.html$/)
-    next unless man_page_name_matched
-
-    man_page_name = man_page_name_matched[1].gsub(/\.\d+$/, '').gsub('-', '_')
-    man_page_name = 'gemfile_man' if man_page_name == 'gemfile'
-
-    proxy "/#{version}/#{man_page_name}.html", page_path unless man_page_exists?(man_page_name, version)
+    handle_man_page(file_path) do |man_page_name, page_path|
+      proxy "/#{version}/#{man_page_name}.html", page_path unless man_page_exists?(man_page_name, version)
+    end
   end
 end
 

--- a/lib/config/utils.rb
+++ b/lib/config/utils.rb
@@ -7,3 +7,16 @@ def man_page_exists?(man_page_name, version)
   File.exist?("./source/#{version}/#{man_page_name}.html") ||
     File.exist?("./source/#{version}/#{man_page_name}.html.haml")
 end
+
+def handle_man_page(file_path)
+  file_path = file_path[0..-5]
+  page_path = file_path.sub(/^\.\/source/, '')
+
+  man_page_name_matched = file_path.match(/man\/(.*)\.html$/)
+  return unless man_page_name_matched
+
+  man_page_name = man_page_name_matched[1].gsub(/\.\d+$/, '').gsub('-', '_')
+  man_page_name = 'gemfile_man' if man_page_name == 'gemfile'
+
+  yield man_page_name, page_path if block_given?
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`https://bundler.io/bundle_config.html` would be available instead of `Page not found` (see #536).

### What was your diagnosis of the problem?

My diagnosis is to face `404 page not found` for `https://bundler.io/bundle_config.html`.

### What is your fix for the problem, implemented in this PR?

This PR fixes to add proxies from `/v2.1/<man-based-CLI-reference>.html` to `/<man-based-CLI-reference>.html`.

When v2.1 is the latest version of bundler, copy man-based docs to the top-level directory to avoid dead links as well as backward compatibility.

`/v2.1/bundle_config.html` (adapted from `bundler/bundler`) would be available at `/bundle_config.html` as well.

Keeping to use `bundler/bundler` instead of `bundler` dir of `rubygems/rubygems` is **NOT** a scope of this PR.

### Why did you choose this fix out of the possible options?

I chose this fix because the existing implementation uses `proxy` instead of  while I prefer redirections to avoid duplication.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
