### PR TITLE
Remove an extra empty line from bundler console

### DIFF
--- a/source/v1.10/bundle_console.html.haml
+++ b/source/v1.10/bundle_console.html.haml
@@ -11,7 +11,6 @@ description: Start an interactive Ruby console session in the context of the cur
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.11/bundle_console.html.haml
+++ b/source/v1.11/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.13/bundle_console.html.haml
+++ b/source/v1.13/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.14/bundle_console.html.haml
+++ b/source/v1.14/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.15/bundle_console.html.haml
+++ b/source/v1.15/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.16/bundle_console.html.haml
+++ b/source/v1.16/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.17/bundle_console.html.haml
+++ b/source/v1.17/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.6/bundle_console.html.haml
+++ b/source/v1.6/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Opens an IRB session with the bundle pre-loaded
     :code
       $ bundle console [GROUP]
-
     .description
       Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.7/bundle_console.html.haml
+++ b/source/v1.7/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Opens an IRB session with the bundle pre-loaded
     :code
       $ bundle console [GROUP]
-
     .description
       Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.8/bundle_console.html.haml
+++ b/source/v1.8/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v1.9/bundle_console.html.haml
+++ b/source/v1.9/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v2.0/bundle_console.html.haml
+++ b/source/v2.0/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code

--- a/source/v2.1/bundle_console.html.haml
+++ b/source/v2.1/bundle_console.html.haml
@@ -6,7 +6,6 @@
       Start an interactive Ruby console session in the context of the current bundle
     :code
       $ bundle console [GROUP]
-
     .description
       <code>bundle console</code> uses irb by default. Alternatives like Pry and Ripl can be used with bundle console by adjusting the <code>console</code> Bundler setting. Also make sure that <code>pry</code> or <code>ripl</code> is in your Gemfile.
     :code


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

https://bundler.io/bundle_console.html

![bundler io_bundle_console html(iPad Pro)](https://user-images.githubusercontent.com/10229505/98193480-a5910c00-1f60-11eb-955a-e95ff5f60697.png)

https://bundler.io/v2.1/bundle_console.html

![bundler io_v2 1_bundle_console html(iPad Pro)](https://user-images.githubusercontent.com/10229505/98193488-a9bd2980-1f60-11eb-8289-9220b5138ee0.png)

### What is your fix for the problem, implemented in this PR?

Removes an extra empty line from bundler console.
![after](https://user-images.githubusercontent.com/10229505/98193474-a2961b80-1f60-11eb-986a-b6c0586e62c4.png)

### Why did you choose this fix out of the possible options?

I chose this fix because formatting should be consistent with other pages.
