### PR TITLE
CI: Use Bundler 2.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 rvm:
   - 2.7.2
 install:
-  - gem install bundler:2.2.4
+  - gem install bundler:2.2.5
   - bundle install --deployment
   - eval "$(ssh-agent -s)"
 script:


### PR DESCRIPTION


### What was the end-user problem that led to this PR?

I noted we were using not-latest version in the CI configuration (which we are moving away from).



### What was your diagnosis of the problem?

My diagnosis was the version was 1 patch behind latest.

### What is your fix for the problem, implemented in this PR?

My fix was to use 2.2.5, latest.

### Why did you choose this fix out of the possible options?

This change was just to keep up-to-date, I don't know of any changes in Bundler that we rely on.

