### PR TITLE
Bump kramdown to fix security issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,4 +221,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.11
+   2.2.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jquery-middleman (3.1.2)
       thor (>= 0.14, < 2.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     libv8 (3.16.14.19)
     libv8 (3.16.14.19-x86_64-linux)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that gihub alerted us of a security issue in the kramdown dependency.

### What is your fix for the problem, implemented in this PR?

My fix is to upgrade kramdown.