### PR TITLE
Fix a broken link on plugin page

### DIFF
--- a/source/v2.1/bundle_plugin.html.haml
+++ b/source/v2.1/bundle_plugin.html.haml
@@ -8,7 +8,7 @@
       %ul
         %li
           See also
-          = link_to 'How to write a Bundler plugin', './guides/bundler_plugins.html.haml'
+          = link_to 'How to write a Bundler plugin', './guides/bundler_plugins.html'
         %li
           In 2.2.0, an additional <code>uninstall</code> command will be added.
     :code

--- a/source/v2.2/bundle_plugin.html.haml
+++ b/source/v2.2/bundle_plugin.html.haml
@@ -8,7 +8,7 @@
       %ul
         %li
           See also
-          = link_to 'How to write a Bundler plugin', './guides/bundler_plugins.html.haml'
+          = link_to 'How to write a Bundler plugin', './guides/bundler_plugins.html'
         %li
           In 2.2.0, an additional <code>uninstall</code> command will be added.
     :code


### PR DESCRIPTION
The link should be `.html`, not `.html.haml`

### What was the end-user problem that led to this PR?

The problem was the link in https://bundler.io/v2.2/bundle_plugin.html was broken.

### What was your diagnosis of the problem?

My diagnosis was the link is `.html.haml`.

### What is your fix for the problem, implemented in this PR?

My fix is to remove `.haml` part from the link.

### Why did you choose this fix out of the possible options?

I chose this fix because other working links end with `.html`, not `.html.haml`.
