### PR TITLE
Fix an example in Git Guide

### DIFF
--- a/source/v2.2/guides/git.html.haml
+++ b/source/v2.2/guides/git.html.haml
@@ -113,6 +113,7 @@ title: How to install gems from git repositories
         # lang: ruby
         gem 'capistrano-sidekiq', github: 'seuros/capistrano-sidekiq'
         gem 'keystone', bitbucket: 'musicone/keystone'
+        gem 'my_gist', gist: '4815162342'
   %h2 Custom git sources
   .contents
     .bullet

--- a/source/v2.2/guides/git.html.haml
+++ b/source/v2.2/guides/git.html.haml
@@ -111,7 +111,6 @@ title: How to install gems from git repositories
         There are analogous shortcuts for Bitbucket (<code>:bitbucket</code>) and GitHub Gists (<code>:gist</code>).
       :code
         # lang: ruby
-        gem 'capistrano-sidekiq', github: 'seuros/capistrano-sidekiq'
         gem 'keystone', bitbucket: 'musicone/keystone'
         gem 'my_gist', gist: '4815162342'
   %h2 Custom git sources


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The example for `gist:` sources in the [Git Guide](https://bundler.io/v2.2/guides/git.html) was for a `git:` source instead.

### What was your diagnosis of the problem?

n/a

### What is your fix for the problem, implemented in this PR?

Replace it with a `gist:` example.

### Why did you choose this fix out of the possible options?

n/a