### PR TITLE
Update GlobalSignRootCA cert link

### DIFF
--- a/source/v2.2/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/v2.2/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -240,7 +240,7 @@ instructions in this guide for upgrading Ruby as well.
 
 **Step 1: Get the new trust certificate**
 
-Download the `.pem` file from this link: [GlobalSignRootCA.pem](https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/index.rubygems.org/GlobalSignRootCA.pem)
+Download the `.pem` file from this link: [GlobalSignRootCA.pem](https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem)
 
 Then, find the downloaded file, and check to make sure the filename ends in `.pem`.
 (*Note*: Some browsers will change the extension to `.txt`, which will prevent this from working.


### PR DESCRIPTION
Related: https://github.com/rubygems/bundler-site/pull/541

current link returns 404.