### PR TITLE
Update the Contributing link to the new URI

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -68,13 +68,13 @@
     .col-md-12
       %h2#get-involved Get involved
       .large-font
-        Bundler has a lot of contributors and users, and we would love to have your help! If you have questions, join #{link_to 'the Bundler Slack', 'http://slack.bundler.io'} and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with #{link_to 'the contributing guide', 'https://github.com/bundler/bundler/blob/master/doc/contributing/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you think you've found a security issue, please report it via #{link_to 'HackerOne', 'https://hackerone.com/rubygems'}.
+        Bundler has a lot of contributors and users, and we would love to have your help! If you have questions, join #{link_to 'the Bundler Slack', 'http://slack.bundler.io'} and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with #{link_to 'the contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you think you've found a security issue, please report it via #{link_to 'HackerOne', 'https://hackerone.com/rubygems'}.
 
       .contents
         .buttons
           = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary'
           = link_to 'Join the Bundler Slack', 'http://slack.bundler.io', class: 'btn btn-primary'
-          = link_to 'Contributing guide', 'https://github.com/bundler/bundler/blob/master/doc/contributing/README.md', class: 'btn btn-primary'
+          = link_to 'Contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary'
           = link_to 'Report security issue', 'https://hackerone.com/rubygems', class: 'btn btn-primary'
 
 :css

--- a/source/v2.2/index.html.haml
+++ b/source/v2.2/index.html.haml
@@ -135,12 +135,12 @@
 
 %h2#get-involved Get involved
 %p.contents
-  Bundler has a lot of contributors and users, and they all talk to each other quite a bit. If you have questions, try #{link_to 'the IRC channel', 'http://webchat.freenode.net/?channels=bundler'} or #{link_to 'mailing list', 'http://groups.google.com/group/ruby-bundler'}. If you're interested in contributing to the project (no programming skills needed), read #{link_to 'the contributing guide', 'https://github.com/bundler/bundler/blob/master/doc/contributing/README.md'} or #{link_to 'the development guide', 'https://github.com/bundler/bundler/blob/master/doc/development/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you have sponsorship or security questions, please contact the core team directly.
+  Bundler has a lot of contributors and users, and they all talk to each other quite a bit. If you have questions, try #{link_to 'the IRC channel', 'http://webchat.freenode.net/?channels=bundler'} or #{link_to 'mailing list', 'http://groups.google.com/group/ruby-bundler'}. If you're interested in contributing to the project (no programming skills needed), read #{link_to 'the contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md'} or #{link_to 'the development guide', 'https://github.com/bundler/bundler/blob/master/doc/development/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you have sponsorship or security questions, please contact the core team directly.
 
 .contents
   .buttons
     = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary'
     = link_to '#bundler on IRC', 'http://webchat.freenode.net/?channels=bundler', class: 'btn btn-primary'
     = link_to 'Mailing list', 'http://groups.google.com/group/ruby-bundler', class: 'btn btn-primary'
-    = link_to 'Contributing', 'https://github.com/bundler/bundler/blob/master/doc/contributing/README.md', class: 'btn btn-primary'
+    = link_to 'Contributing', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary'
     = link_to 'Email core team', 'mailto:team@bundler.io', class: 'btn btn-primary'


### PR DESCRIPTION
I made the change in the index file and in the v2.2


### What was the end-user problem that led to this PR?

The problem was that the links were pointing to the old repo.

### What was your diagnosis of the problem?

My diagnosis was we needed to update them to current ones.

### What is your fix for the problem, implemented in this PR?

My fix is to point to the README in the rubygems/rubygems repo.

### Why did you choose this fix out of the possible options?

I chose this fix – fixing the source file and the latest generated version's HTML, since it was quick to do, and not too onerous to review.

Also: this is a focused change, which does not do All The Things.
