### PR TITLE
Windows: Add a hint for possible subdirectories for ssl_certs

### DIFF
--- a/source/v2.2/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/v2.2/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -287,8 +287,9 @@ A Finder window will open showing the directory that RubyGems is installed into.
 
 **Step 3: Copy new trust certificate**
 
-In the window, open the `ssl_certs` directory and drag your `.pem`
-file into it. It will be listed with other files like `AddTrustExternalCARoot.pem`.
+In the window, open the `ssl_certs` directory. Find other `.pem` files like
+`AddTrustExternalCARoot.pem` (may be located in subdirectories like `rubygems.org`)
+and drag your file beside them.
 
 Once you’ve done this, it should be possible to follow the directions at the very top to
 automatically update RubyGems. Visit the [Update RubyGems][update-rubygems] section for


### PR DESCRIPTION
As mentioned in #540, existing .pem files might exist in subdirectories rather than in the ssl_certs directory directly.

I was unsure, if the difference (subdirectory or not) is, because I have a linux system rather than Windows/macOS. But as the macOs description is otherwise identical to the linux workflow I did choose to not add extra steps

Fixes #540