### PR TITLE
Second tweak to dependency confusion blog post

### DIFF
--- a/source/blog/2021-02-15-a-more-secure-bundler-we-fixed-our-source-priorities.html.markdown
+++ b/source/blog/2021-02-15-a-more-secure-bundler-we-fixed-our-source-priorities.html.markdown
@@ -9,10 +9,9 @@ category: security
 
 ---
 
-> __NOTE__: As of bundler 2.2.15, the part about the Bundler release in this
-> blog post is not fully relevant. Issue has been partially addressed for
-> situations where there's an existing lockfile, but we're still working on
-> fixing it when there's no lockfile.
+> __NOTE__: Whereas the issue was initially fixed in bundler 2.2.10, it had to
+> be reverted due to several problems caused by the initial approach. A proper
+> fix was finally released with bundler 2.2.18.
 
 ## What happened?
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was since we have finally released a fix, the blog post about dependency confusion issues is out of date again.

### What was your diagnosis of the problem?

My fix is to update the blog post again and pray this problem is gone for good now.
