### PR TITLE
Update middleman 4.3.11+patches to 4.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'middleman', '~> 4.3', github: "middleman/middleman", branch: "4.x"
 gem 'middleman-syntax'
 gem 'middleman-blog'
 gem 'puma', '~> 4.3'
-gem 'middleman-search'
+gem 'middleman-search', github: 'deivid-rodriguez/middleman-search', branch: 'workarea-commerce-master'
 gem 'rake'
 gem 'ronn'
 gem 'kramdown'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby File.read(File.expand_path('../.ruby-version', __FILE__)).strip
 
 gem 'octokit', '~> 4.15'
-gem 'middleman', '~> 4.3', github: "middleman/middleman", branch: "4.x"
+gem 'middleman', '~> 4.4'
 gem 'middleman-syntax'
 gem 'middleman-blog'
 gem 'puma', '~> 4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,4 +185,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.2.15
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    nokogiri (1.12.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     octokit (4.15.0)
@@ -160,6 +162,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/deivid-rodriguez/middleman-search.git
+  revision: 50465e1c1580e282a45247b77036da3c2719870d
+  branch: workarea-commerce-master
+  specs:
+    middleman-search (0.10.0)
+      middleman-core (>= 3.2)
+      mini_racer (~> 0.5)
+      nokogiri (~> 1.6)
+
+GIT
   remote: https://github.com/middleman/middleman.git
   revision: 0c950d82f6f4f540e8572195f80c9a9fb15ab80c
   branch: 4.x
@@ -76,8 +86,9 @@ GEM
       concurrent-ruby (~> 1.0)
     kramdown (2.3.1)
       rexml
-    libv8 (3.16.14.19)
-    libv8 (3.16.14.19-x86_64-linux)
+    libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-arm64-darwin)
+    libv8-node (16.10.0.0-x86_64-linux)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -87,14 +98,12 @@ GEM
       addressable (~> 2.3)
       middleman-core (>= 4.0.0)
       tzinfo (>= 0.3.0)
-    middleman-search (0.10.0)
-      middleman-core (>= 3.2)
-      nokogiri (~> 1.6)
-      therubyracer (~> 0.12.2)
     middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     mini_portile2 (2.6.1)
+    mini_racer (0.5.0)
+      libv8-node (~> 16.10.0.0)
     minitest (5.14.4)
     multipart-post (2.1.1)
     mustache (1.0.5)
@@ -133,7 +142,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rdiscount (2.2.0.2)
-    ref (2.0.0)
     rexml (3.2.5)
     ronn (0.7.3)
       hpricot (>= 0.8.2)
@@ -147,9 +155,6 @@ GEM
       faraday (> 0.8, < 2.0)
     servolux (0.13.0)
     temple (0.8.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -172,7 +177,7 @@ DEPENDENCIES
   kramdown
   middleman (~> 4.3)!
   middleman-blog
-  middleman-search
+  middleman-search!
   middleman-syntax
   nokogiri (~> 1.12)
   octokit (~> 4.15)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,53 +8,15 @@ GIT
       mini_racer (~> 0.5)
       nokogiri (~> 1.6)
 
-GIT
-  remote: https://github.com/middleman/middleman.git
-  revision: 0c950d82f6f4f540e8572195f80c9a9fb15ab80c
-  branch: 4.x
-  specs:
-    middleman (4.3.11)
-      coffee-script (~> 2.2)
-      haml (>= 4.0.5)
-      kramdown (>= 2.3.0)
-      middleman-cli (= 4.3.11)
-      middleman-core (= 4.3.11)
-    middleman-cli (4.3.11)
-      thor (>= 0.17.0, < 2.0)
-    middleman-core (4.3.11)
-      activesupport (>= 4.2, < 6.0)
-      addressable (~> 2.3)
-      backports (~> 3.6)
-      bundler (~> 2.0)
-      contracts (~> 0.13.0)
-      dotenv
-      erubis
-      execjs (~> 2.0)
-      fast_blank
-      fastimage (~> 2.0)
-      hamster (~> 3.0)
-      hashie (~> 3.4)
-      i18n (~> 0.9.0)
-      listen (~> 3.0.0)
-      memoist (~> 0.14)
-      padrino-helpers (~> 0.13.0)
-      parallel
-      rack (>= 1.4.5, < 3)
-      sassc (~> 2.0)
-      servolux
-      tilt (~> 2.0.9)
-      toml
-      uglifier (~> 3.0)
-      webrick
-
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.5)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     backports (3.21.0)
@@ -65,16 +27,16 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     contracts (0.13.0)
     dotenv (2.7.6)
     erubis (2.7.0)
-    execjs (2.7.0)
+    execjs (2.8.1)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    fast_blank (1.0.0)
-    fastimage (2.2.3)
-    ffi (1.15.0)
+    fast_blank (1.0.1)
+    fastimage (2.2.5)
+    ffi (1.15.4)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -82,7 +44,7 @@ GEM
       concurrent-ruby (~> 1.0)
     hashie (3.6.0)
     hpricot (0.8.6)
-    i18n (0.9.5)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     kramdown (2.3.1)
       rexml
@@ -94,10 +56,43 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.2)
     method_source (0.9.2)
+    middleman (4.4.2)
+      coffee-script (~> 2.2)
+      haml (>= 4.0.5)
+      kramdown (>= 2.3.0)
+      middleman-cli (= 4.4.2)
+      middleman-core (= 4.4.2)
     middleman-blog (4.0.3)
       addressable (~> 2.3)
       middleman-core (>= 4.0.0)
       tzinfo (>= 0.3.0)
+    middleman-cli (4.4.2)
+      thor (>= 0.17.0, < 2.0)
+    middleman-core (4.4.2)
+      activesupport (>= 6.1, < 7.0)
+      addressable (~> 2.4)
+      backports (~> 3.6)
+      bundler (~> 2.0)
+      contracts (~> 0.13.0)
+      dotenv
+      erubis
+      execjs (~> 2.0)
+      fast_blank
+      fastimage (~> 2.0)
+      hamster (~> 3.0)
+      hashie (~> 3.4)
+      i18n (~> 1.6.0)
+      listen (~> 3.0.0)
+      memoist (~> 0.14)
+      padrino-helpers (~> 0.15.0)
+      parallel
+      rack (>= 1.4.5, < 3)
+      sassc (~> 2.0)
+      servolux
+      tilt (~> 2.0.9)
+      toml
+      uglifier (~> 3.0)
+      webrick
     middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
@@ -118,14 +113,13 @@ GEM
     octokit (4.15.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    padrino-helpers (0.13.3.4)
-      i18n (~> 0.6, >= 0.6.7)
-      padrino-support (= 0.13.3.4)
+    padrino-helpers (0.15.1)
+      i18n (>= 0.6.7, < 2)
+      padrino-support (= 0.15.1)
       tilt (>= 1.4.1, < 3)
-    padrino-support (0.13.3.4)
-      activesupport (>= 3.1)
-    parallel (1.20.1)
-    parslet (1.8.2)
+    padrino-support (0.15.1)
+    parallel (1.21.0)
+    parslet (2.0.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -138,7 +132,7 @@ GEM
     racc (1.5.2)
     rack (2.2.3)
     rake (13.0.1)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rdiscount (2.2.0.2)
@@ -156,15 +150,15 @@ GEM
     servolux (0.13.0)
     temple (0.8.2)
     thor (1.1.0)
-    thread_safe (0.3.6)
     tilt (2.0.10)
-    toml (0.2.0)
-      parslet (~> 1.8.0)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    toml (0.3.0)
+      parslet (>= 1.8.0, < 3.0.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     webrick (1.7.0)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   arm64-darwin-21
@@ -175,7 +169,7 @@ DEPENDENCIES
   builder
   haml (~> 5.1.2)
   kramdown
-  middleman (~> 4.3)!
+  middleman (~> 4.4)
   middleman-blog
   middleman-search!
   middleman-syntax


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was nothing. Just that the middleman version was pinned in #552 so we were not able to get dependency updates from dependabot. Some vulnerable dependency was introduced in #552 (but fixed in #562 later).

### What was your diagnosis of the problem?

n/a

### What is your fix for the problem, implemented in this PR?

My fix is to upgrade activesupport from 5.2 to 6.1 to fully use Ruby 3.0.

### Why did you choose this fix out of the possible options?

To simplify dependencies.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
