### PR TITLE
build: Document bundler-cache, and rely on it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Bundle Install
-        run: |
-          bundle config set --local deployment true
-          bundle install
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Install Node.js
         uses: actions/setup-node@v1
@@ -30,4 +25,6 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: NO_CONTRACTS=true bundle exec middleman build
+        run: bundle exec middleman build
+        env:
+          NO_CONTRACTS: "true"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Bundle Install
-        run: |
-          bundle config set --local deployment true
-          bundle install
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Install Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was very minor: CI looked like it did 2 `bundle install` actions.

### What was your diagnosis of the problem?

My diagnosis was that we could use ruby/setup-ruby's `bundler-cache: true` and only that.

### What is your fix for the problem, implemented in this PR?

My fix was to remove the extra bundle install step. And then to document the `bundler-cache: true` setting in all places used.

### Why did you choose this fix out of the possible options?

I chose this fix because I wanted speed and clarity configuration.
