### PR TITLE
bundle update thor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       faraday (> 0.8, < 2.0)
     servolux (0.13.0)
     temple (0.8.2)
-    thor (1.1.0)
+    thor (1.2.1)
     tilt (2.0.10)
     toml (0.3.0)
       parslet (>= 1.8.0, < 3.0.0)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A warning when booting the app

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

### What is your fix for the problem, implemented in this PR?

`bundle update thor`.