### PR TITLE
Fix dead links on GitHub from man pages

### DIFF
--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -11,23 +11,34 @@ module DocsHelper
   end
 
   def link_to_editable_version
+    editable = true
     path = current_page.file_descriptor.relative_path.to_s
     repo =
       if path.start_with?('doc/')
         path = "bundler/#{path}"
         'rubygems/rubygems'
-      elsif path =~ %r{\Av\d+\.\d+/man/(bundle[_-]|gemfile)}
-        path = "#{strip_version_from_url(path)}.ronn"
-        path = "bundler/#{path}"
+      elsif %r{\A(?<version>v\d+\.\d+)/man/(?<filename>(bundle[_-]|gemfile)[^/]*)\.html} =~ path
+        if version == current_version
+          path = "bundler/lib/bundler/man/#{filename}.ronn"
+        else
+          editable = false
+        end
         'rubygems/rubygems'
       else
         path = File.join 'source', path
         'rubygems/bundler-site'
       end
-    url = "https://github.com/#{repo}/blob/master/#{path}"
 
-    link_to('Edit this document on GitHub', url) +
-      ' if you caught an error or noticed something was missing.'
+    if editable
+      url = "https://github.com/#{repo}/blob/master/#{path}"
+      link_to('Edit this document on GitHub', url) +
+        ' if you caught an error or noticed something was missing.'
+    else
+      url = "/" + path.sub(version, current_version).sub(/\.html.*/, '.html')
+      'This document is obsolete. ' +
+        link_to('See the latest version of this document', url) +
+        ' if you caught an error or noticed something was missing, it may be fixed there.'
+    end
   end
 
   def path_exist?(page, version=nil)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Dead links to source Git happen on both for v2.3 and earlier man pages.

Example:

https://bundler.io/v2.3/man/bundle-install.1.html has a link entitled as "Edit this document on GitHub" to `https://github.com/rubygems/rubygems/blob/master/bundler/man/bundle-install.1.ronn`, which is dead.

### What was your diagnosis of the problem?

This regression has happened since 2020-09-04 with https://github.com/rubygems/rubygems/pull/3921.
A solution for this problem was not included in #542.

### What is your fix for the problem, implemented in this PR?

Fixes the dead links on GitHub from man pages from the current version of Bundler (2.3 as of writing).

Removes the dead links on GitHub from man pages from the non-current version of Bundler (1.12 through 2.2 as of writing). Instead of that, the link to the latest version's man is added there.

### Why did you choose this fix out of the possible options?

~~An end-user (website reader) should be able to consider if they can improve older Bundler man pages like 1.12 etc.~~

As the legacy Bundler maintenance policy will be updated in https://github.com/rubygems/rubygems/issues/5647, we do not have to take care about something wrong in man pages in Bundler 2.2 or earlier.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

Partially resolves #620