### PR TITLE
Fix dead links to GitHub on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ bundler.io is intended to serve as a convenient source for documentation on the 
 
 The site bundler.io is a static site generated using [Middleman](http://middlemanapp.com/).
 
-[Bundler's manual pages](https://github.com/rubygems/rubygems/tree/master/bundler/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
+[Bundler's manual pages](https://github.com/rubygems/rubygems/tree/master/bundler/lib/bundler/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
 
 ## Development Set Up
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A link to GitHub in README.md is now dead due to rubygems/rubygems#3921 since 2020-09-04

- https://github.com/rubygems/rubygems/pull/3921

### What is your fix for the problem, implemented in this PR?

Just fix it.

### Why did you choose this fix out of the possible options?

Apart from this, links from each man page will be fixed in:
- https://github.com/rubygems/bundler-site/pull/615

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>