### PR TITLE
Fix link to CLI docs with the latest one

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -15,7 +15,7 @@
       %p.text-center
         = link_to t('home.what_can_bundler_do'), "./#{current_version}/#getting-started", class: 'btn btn-primary btn-lg btn-responsive'
         = link_to "#{t("home.new_in")} #{current_version}", '/whats_new.html', class: 'btn btn-primary btn-lg btn-responsive'
-        = link_to t('home.cli_docs'), './man/bundle-install.1.html', class: 'btn btn-primary btn-lg btn-responsive'
+        = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg btn-responsive'
         = link_to t('home.chat_with_us'), 'http://slack.bundler.io', class: 'btn btn-primary btn-lg btn-responsive'
 
 .row.bg-light-blue


### PR DESCRIPTION
A link to CLI docs from https://bundler.io/ is changed from https://bundler.io/man/bundle-install.1.html to https://bundler.io/v2.3/man/bundle-install.1.html

The link changed is pointed as follows:
![bundler-top](https://user-images.githubusercontent.com/10229505/175322741-38b5bf96-13e5-4a00-980c-9d03d56ef1e9.png)

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>