### PR TITLE
Remove redundant date from frontmatters in blog

### DIFF
--- a/source/blog/2018-08-10-july-bundler-update.html.markdown
+++ b/source/blog/2018-08-10-july-bundler-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "July 2018 Bundler Update"
-date: 2018-08-10 
 tags:
 author: Stephanie Morillo
 author_url: http://www.stephaniemorillo.co

--- a/source/blog/2018-09-10-august-bundler-update.html.markdown
+++ b/source/blog/2018-09-10-august-bundler-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "August 2018 Bundler Update"
-date: 2018-09-10 
 tags:
 author: Stephanie Morillo
 author_url: http://www.stephaniemorillo.co

--- a/source/blog/2018-10-15-september-monthly-update.html.markdown
+++ b/source/blog/2018-10-15-september-monthly-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "September 2018 Bundler Update"
-date: 2018-10-15
 tags:
 author: Stephanie Morillo
 author_url: http://www.stephaniemorillo.co

--- a/source/blog/2018-10-25-announcing-bundler-1-17-0.html.markdown
+++ b/source/blog/2018-10-25-announcing-bundler-1-17-0.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "Announcing Bundler 1.17.0"
-date: 2018-10-25
 tags:
 author: Colby Swandale
 category: release

--- a/source/blog/2018-11-04-an-update-on-bundler-2.html.markdown
+++ b/source/blog/2018-11-04-an-update-on-bundler-2.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "An Update on Bundler 2.0"
-date: 2018-11-04
 tags:
 author: Colby Swandale & André Arko
 category: release

--- a/source/blog/2018-11-05-october-monthly-update.html.markdown
+++ b/source/blog/2018-11-05-october-monthly-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "October 2018 Bundler Update"
-date: 2018-11-05
 tags:
 author: Stephanie Morillo
 author_url: http://www.stephaniemorillo.co

--- a/source/blog/2018-12-08-november-monthly-update.html.markdown
+++ b/source/blog/2018-12-08-november-monthly-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "November 2018 Bundler Update"
-date: 2018-12-08
 tags:
 author: Stephanie Morillo
 ---

--- a/source/blog/2019-01-03-announcing-bundler-2.html.markdown
+++ b/source/blog/2019-01-03-announcing-bundler-2.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "Announcing Bundler 2.0"
-date: 2019-01-03
 tags:
 author: Colby Swandale
 category: release

--- a/source/blog/2019-01-04-an-update-on-the-bundler-2-release.html.markdown
+++ b/source/blog/2019-01-04-an-update-on-the-bundler-2-release.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "An update on the Bundler 2 release"
-date: 2019-01-04
 tags:
 author: Colby Swandale
 category: release

--- a/source/blog/2019-02-02-december-monthly-update.html.markdown
+++ b/source/blog/2019-02-02-december-monthly-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "December 2018 Bundler Update"
-date: 2019-02-02
 tags:
 author: Stephanie Morillo
 ---

--- a/source/blog/2019-03-12-january-february-bimonthly-update.html.markdown
+++ b/source/blog/2019-03-12-january-february-bimonthly-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "January and February Bundler Update"
-date: 2019-03-12
 tags:
 author: Stephanie Morillo
 ---

--- a/source/blog/2019-05-14-solutions-for-cant-find-gem-bundler-with-executable-bundle.html.markdown
+++ b/source/blog/2019-05-14-solutions-for-cant-find-gem-bundler-with-executable-bundle.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "Solutions for 'Cant find gem bundler (>= 0.a) with executable bundle'"
-date: 2019-05-14
 tags:
 author: Colby Swandale
 category: release

--- a/source/blog/2020-04-27-march-monthly-update.html.markdown
+++ b/source/blog/2020-04-27-march-monthly-update.html.markdown
@@ -1,6 +1,5 @@
 ---
 title: "March Bundler Update"
-date: 2020-04-27
 tags:
 author: Gift Egwuenu
 ---


### PR DESCRIPTION
`date` should be `YYYY/MM/DD`, `YYYY-MM-DD anything`, or omitted. Otherwise title will miss.

Closes #621

Currently `date` field is `YYYY-MM-DD` (no time and no timezone, which is redundant with date in the filename, so we can remove them.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)