### PR TITLE
Fix wrong options for Middleman

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Run a local development web server:
 
 This will start a local web server running at: *http://localhost:4567*. It will serve the site as it exists in **/source**.
 
-To specify the host and/or port, add the -h, -p flag(s):
+To specify the host and/or port, add the --bind-address, -p flag(s):
 
-    bundle exec middleman -h 0.0.0.0 -p 8080
+    bundle exec middleman --bind-address 0.0.0.0 -p 8080
 
 Note: the development server will automatically reload pages when they or there associated stylesheets are modified. This feature is enabled in **config.rb**.
 


### PR DESCRIPTION
Middleman does not accept `-h` but `--bind-address`.

```
$ bundle exec middleman --help
Usage:
  middleman middleman:cli:server

Options:
  -e, [--environment=ENVIRONMENT]                                  
  -p, [--port=PORT]                                                
      [--server-name=SERVER_NAME]                                  # The server name of preview server
      [--bind-address=BIND_ADDRESS]                                # The bind address of the preview server
      [--verbose], [--no-verbose]                                  # Print debug messages
      [--instrument], [--no-instrument]                            # Print instrument messages
      [--profile], [--no-profile]                                  # Generate profiling report for server startup
  -d, [--daemon], [--no-daemon]                                    # Daemonize preview server
      [--automatic-directory-matcher=AUTOMATIC_DIRECTORY_MATCHER]  # Set to automatically convert some characters into a directory
      [--build-dir=BUILD_DIR]                                      # Where to build output files
      [--css-dir=CSS_DIR]                                          # Location of stylesheets within source
      [--current-version=CURRENT_VERSION]                          
      [--data-dir=DATA_DIR]                                        # The directory data files are stored in
      [--disable-sitemap], [--no-disable-sitemap]                  # If we should not run the sitemap.
      [--encoding=ENCODING]                                        # Default string encoding for templates and output
      [--exit-before-ready], [--no-exit-before-ready]              # If we should exit before ready event.
      [--fonts-dir=FONTS_DIR]                                      # Location of fonts within source
      [--helpers-dir=HELPERS_DIR]                                  # Directory to autoload helper modules from
      [--helpers-filename-glob=HELPERS_FILENAME_GLOB]              # Glob pattern for matching helper ruby files
      [--http-prefix=HTTP_PREFIX]                                  # Default prefix for building paths
      [--https], [--no-https]                                      # Serve the preview server over SSL/TLS
      [--images-dir=IMAGES_DIR]                                    # Location of images within source
      [--index-file=INDEX_FILE]                                    # Which file should be used for directory indexes
      [--js-dir=JS_DIR]                                            # Location of javascripts within source
      [--layouts-dir=LAYOUTS_DIR]                                  # Location of layouts within source
      [--protect-from-csrf], [--no-protect-from-csrf]              # Should Padrino include CRSF tag
      [--relative-links], [--no-relative-links]                    # Whether to generate relative links instead of absolute ones
      [--sass-source-maps=SASS_SOURCE_MAPS]                        # Whether to inline sourcemap into Sass
      [--show-exceptions], [--no-show-exceptions]                  # Whether to catch and display exceptions
      [--source=SOURCE]                                            # Name of the source directory
      [--ssl-certificate=SSL_CERTIFICATE]                          # Path to an X.509 certificate to use for the preview server
      [--ssl-private-key=SSL_PRIVATE_KEY]                          # Path to an RSA private key for the preview server's certificate
      [--strip-index-file], [--no-strip-index-file]                # Whether to strip the index file name off links to directory indexes
      [--trailing-slash], [--no-trailing-slash]                    # Whether to include a trailing slash when stripping the index file
      [--versions=VERSIONS]                                        
      [--watcher-disable], [--no-watcher-disable]                  # If the Listen watcher should not run
      [--watcher-force-polling], [--no-watcher-force-polling]      # If the Listen watcher should run in polling mode
      [--watcher-latency=WATCHER_LATENCY]                          # The Listen watcher latency
```

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)