### PR TITLE
Update Spanish guides to catch up with latest changes

### DIFF
--- a/source/localizable/v2.3/guides/bundler_setup.es.html.haml
+++ b/source/localizable/v2.3/guides/bundler_setup.es.html.haml
@@ -1,0 +1,108 @@
+---
+title: Usando Bundler con Ruby
+---
+
+.container.guide
+  %h2 Cómo usar Bundler con Ruby
+
+  .contents
+    .bullet
+      .description
+        Configure la ruta de carga para que todas las dependencias en
+        su Gemfile puedan ser requerídas
+    :code
+      # lang: ruby
+      require 'rubygems'
+      require 'bundler/setup'
+      require 'nokogiri'
+
+    .bullet
+      .description
+        Agregue solamente gemas de grupos específicos
+        a la ruta de carga. Si quiere usar las gemas en el grupo
+        por defecto, inclúyalo
+      :code
+        # lang: ruby
+        require 'rubygems'
+        require 'bundler'
+        Bundler.setup(:default, :ci)
+        require 'nokogiri'
+      = link_to 'Aprende más: Grupos', './groups.html', class: 'btn btn-primary'
+
+    %h2 Compatibilidad
+
+    .contents
+      .bullet
+        .description
+          Tanto Ruby 2.0 como Rubygems 2.0 requieren Bundler 1.13 o superior. Si tiene dudas sobre la compatibilidad entre Bundler y su sistema, por favor chequee la lista de compatibilidad.
+        = link_to 'Aprende más: Compatibilidad', '/compatibility.html', class: 'btn btn-primary'
+
+      %h2#setting-up-your-application-to-use-bundler
+        Configurando su aplicación para usar Bundler
+
+      .bullet
+        .description
+          Bundler asegura que Ruby pueda encontrar todas las gemas en el <code>Gemfile</code>
+          (y todas sus dependencias). Si su aplicación es una aplicación Rails,
+          ya contiene el código necesario para invocar a Bundler.
+
+      .bullet
+        .description
+          Para otro tipo de aplicación (como una aplicación Sinatra), necesitará
+          configurar Bundler antes de intentar requerir otras gemas. Al principio del primer archivo
+          que su aplicación carga (para Sinatra, el archivo que contiene <code>require 'sinatra'</code>),
+          ponga el código siguiente:
+
+        :code
+          # lang: ruby
+          require 'rubygems'
+          require 'bundler/setup'
+
+      .bullet
+        .description
+          Esto automáticamente lee su <code>Gemfile</code>, y hace que todas
+          las gemas en él estén disponibles para Ruby (en terminos
+          técnicos, pone las gemas en "la ruta de carga"). Puede pensarlo
+          como una manera de agregar superpoderes extra a <code>require 'rubygems'</code>.
+
+      .bullet
+        .description
+          Ahora que su código está disponible para Ruby, puede requerir
+          las gemas que necesite. Por ejemplo, puede usar el código <code>require 'sinatra'</code>.
+          Si tiene muchas dependencias, puede que prefiera requerir todas las gemas
+          en su <code>Gemfile</code>. Para hacer esto, ponga el código
+          siguiente inmediatamente después de <code>require 'bundler/setup'</code>:
+
+        :code
+          # lang: ruby
+          Bundler.require(:default)
+        Para nuestro Gemfile de ejemplo, esta línea es lo mismo que:
+
+        :code
+          # lang: ruby
+          require 'rails'
+          require 'rack-cache'
+          require 'nokogiri'
+      .bullet
+        .description
+          Quizá haya observado que la manera correcta de requerir
+          la gema <code>rack-cache</code> es <code>require 'rack/cache'</code>,
+          no <code>require 'rack-cache'</code>. Para decirle a bundler que use
+          <code>require 'rack/cache'</code>, especifíquelo en su Gemfile de la
+          siguiente manera:
+
+        :code
+          # lang: ruby
+          source 'https://rubygems.org'
+
+          gem 'rails', '5.0.0'
+          gem 'rack-cache', require: 'rack/cache'
+          gem 'nokogiri', '~> 1.4.2'
+      .bullet
+        .description
+          Para un <code>Gemfile</code> tan pequeño, aconsejamos no usar
+          <code>Bundler.require</code>, sino requerir las gemas manualmente
+          (especialmente por el hecho que se necesita <code>:require</code> en
+          el <code>Gemfile</code>). Para los <code>Gemfile</code>s mucho más grandes,
+          usar <code>Bundler.require</code> permite a uno no tener que repetir
+          muchos de los mismos requisitos.

--- a/source/localizable/v2.3/guides/bundler_sharing.es.html.haml
+++ b/source/localizable/v2.3/guides/bundler_sharing.es.html.haml
@@ -1,0 +1,61 @@
+---
+title: Compartiendo su código
+---
+.container.guide
+  %h2#sharing
+    Cómo paquetizar y compartir código usando un Gemfile
+  .contents
+    .bullet
+      .description
+        %h3#checking-your-code-into-version-control
+          Chequeando su código en su sistema de control de versiones
+
+        %p
+          Después de desarrollar su aplicación por un tiempo, chequee su código en su sistema de
+          control de versiones con el <code>Gemfile</code> y el <code>Gemfile.lock</code>.
+          Ahora, su repositorio tiene un registro de las versiones exactas de todas las gemas que usó la
+          última vez que usted sabe que la aplicación sirvió. Tenga en mente que mientras su <code>Gemfile</code>
+          lista solamente tres gemas (con diferente grados de rigor de versión), su aplicación
+          depende de muchas gemas cuando se considera todos los requisitos implícitos de todas las gemas
+          que dependen en unas de otras.
+      %p.description
+        Esto es importante: <strong>el <code>Gemfile.lock</code></strong> contiene su código y también código de terceros.
+        El<strong><code>Gemfile.lock</code></strong> hace que su aplicación sea un paquete singular
+        que asegura que su aplicación ejecutó con éxito la última vez que corrió el código.
+        Especificando versiones exáctas del código de terceros que uno depende de su
+        <code>Gemfile</code> no proveería la misma garantía, porque gemas usualmente declaran
+        un rango de versiones para sus dependencias.
+
+      %p.description
+        La próxima vez que ejecuta <code>bundle install</code> en la misma máquina, bundler va a ver
+        que ya tiene todas las dependencias necesarias, y va a omitir el proceso de instalación.
+      %p.description
+        No chequee el directorio <code>.bundle</code>, o ningunos de los archivos dentro de él.
+        Esos archivos son específicos para cada máquina, y se usan para persistir opciones de
+        instalación entre diferentes instancias de ejecutación del comando <code>bundle install</code>.
+      %p.description
+        Si ha ejecutado <code>bundle pack</code>, las gemas (pero no las gemas de git) necesitadas
+        por su bundle van a estar descargadas en <code>vendor/cache</code>. Bundler puede correr sin
+        conectarse al internet (o al servidor RubyGems) si todas las gemas que necesita ya están presentes
+        en ese directorio y están chequeadas en su sistema de control de versiones.
+
+
+    .bullet
+      %h3#sharing-your-application-with-other-developers
+        Compartiendo su aplicación con otros desarrolladores
+
+      %p.description
+        Cuando otros desarrolladores (o usted mismo en otra máquina) chequean su código,
+        va a venir con las versiones exáctas de todo el código de terceros que su aplicación
+        usó en la máquina que usó más reciéntemente para desarrollar (en el <code>Gemfile.lock</code>).
+        Cuando <em>otros</em> ejecuten <code>bundle install</code>, bundler va a encontrar el
+        <code>Gemfile.lock</code> y va a omitir el paso de resolver dependencias.
+
+      %p.description
+        En otras palabras, no va a adivinar cuales versiones de las dependencias debería
+        instalar. En los ejemplos que hemos usado, aunque <code>rack-cache</code> declara una
+        dependencia en <code>rack >= 0.4</code>, sabemos que definitivamente trabaja con <code>rack
+        1.5.2</code>. Aunque Rack lanzaría <code>rack 1.5.3</code>, bundler va a siempre instalar
+        <code>1.5.2</code>, la version exácta de la gema que sabemos que funciona. Esto
+        alivia una gran parte de la carga de mantenimiento de desarrolladores de aplicación, porque
+        todas las máquinas siempre ejecutarán el mismo código de terceros.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was these guides were not updated in recent versions.

### What is your fix for the problem, implemented in this PR?

My fix to adapt the changes applied to the English guides to these translated guides, so they are available to at https://bundler.io/es/v2.3/guides/bundler_setup.html and https://bundler.io/es/v2.3/guides/bundler_setup.html
 and https://bundler.io/es/v2.3/guides/bundler_sharing.html.

```diff
--- source/localizable/v1.15/guides/bundler_setup.es.html.haml	2022-07-06 11:16:59.000000000 +0200
+++ source/localizable/v2.3/guides/bundler_setup.es.html.haml	2022-07-06 11:17:30.000000000 +0200
@@ -3,7 +3,7 @@
 ---
 
 .container.guide
-  %h2 Configurando Bundler
+  %h2 Cómo usar Bundler con Ruby
 
   .contents
     .bullet
@@ -96,7 +96,7 @@
           source 'https://rubygems.org'
 
           gem 'rails', '5.0.0'
-          gem 'rack-cache', :require => 'rack/cache'
+          gem 'rack-cache', require: 'rack/cache'
           gem 'nokogiri', '~> 1.4.2'
       .bullet
         .description
--- source/localizable/v1.15/guides/bundler_sharing.es.html.haml	2022-07-06 11:16:59.000000000 +0200
+++ source/localizable/v2.3/guides/bundler_sharing.es.html.haml	2022-07-06 11:17:31.000000000 +0200
@@ -3,7 +3,7 @@
 ---
 .container.guide
   %h2#sharing
-    Compartiendo su código
+    Cómo paquetizar y compartir código usando un Gemfile
   .contents
     .bullet
       .description
@@ -55,7 +55,7 @@
         En otras palabras, no va a adivinar cuales versiones de las dependencias debería
         instalar. En los ejemplos que hemos usado, aunque <code>rack-cache</code> declara una
         dependencia en <code>rack >= 0.4</code>, sabemos que definitivamente trabaja con <code>rack
-        1.2.1</code>. Aunque Rack lanzaría <code>rack 1.2.2</code>, bundler va a siempre instalar
-        <code>1.2.1</code>, la version exácta de la gema que sabemos que funciona. Esto
+        1.5.2</code>. Aunque Rack lanzaría <code>rack 1.5.3</code>, bundler va a siempre instalar
+        <code>1.5.2</code>, la version exácta de la gema que sabemos que funciona. Esto
         alivia una gran parte de la carga de mantenimiento de desarrolladores de aplicación, porque
         todas las máquinas siempre ejecutarán el mismo código de terceros.
```

### Why did you choose this fix out of the possible options?

I chose this fix because regardless of whether these guides are actually useful for anyone or well translated, I think this unblocks further improvements to unify guides and make them not dependent on the bundler version.
