### PR TITLE
Fix incorrect redirection

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -89,7 +89,7 @@ end
 ["", "pl/"].each do |lang|
   %w[1.12 1.13 1.14].each do |version|
     redirect "#{lang}v#{version}/guides/creating_gem.html", to: "#{lang}v1.15/guides/creating_gem.html"
-    redirect "#{lang}v#{version}/guides/using_bundler_in_applications.html", to: "#{lang}v1.15/using_bundler_in_applications.html"
+    redirect "#{lang}v#{version}/guides/using_bundler_in_applications.html", to: "#{lang}v1.15/guides/using_bundler_in_applications.html"
   end
 end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was one page redirect was incorrect, as per https://github.com/rubygems/bundler-site/pull/624#issuecomment-1176017733.

### What is your fix for the problem, implemented in this PR?

My fix is to add the missing `guides/` part to the target URL.