### PR TITLE
npm install is required to setup dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Begin by cloning the repository onto your location machine:
 Once complete prepare the dependencies by running:
 
     bundle install
+    npm install
 
 ## Basic Middleman Commands
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

### What was the end-user problem that led to this PR?

To run `npm install` in the development setup instruction is not included and the server looks running when `bundle exec middleman server` is executed even without webpack installed.

### What was your diagnosis of the problem?

A novice contributor can set up the environment for development. `npx webpack` dismisses the warning.

### What is your fix for the problem, implemented in this PR?

Just show it in the instruction.

### Why did you choose this fix out of the possible options?

Documentation is now but automation would be the next step.