### PR TITLE
Add .gitpod.yml to make dev env easier

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-ruby-3.1
+
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
+  sudo apt-get install -y nodejs

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: |
+      curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+      sudo apt install -y nodejs
+      bundle config set path vendor/bundle
+      bundle install
+      npm install
+    command: bundle exec middleman server

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Once complete prepare the dependencies by running:
     bundle install
     npm install
 
+Or you can prepare a development environment on Gitpod cloud from the below link:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rubygems/bundler-site)
+
 ## Basic Middleman Commands
 
 Fetch latest documentation from bundler repo (should be done before running local development web server):


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The contribution guide has not been coded so hard for a new contributor to get started to contributions to the repository.

### What was your diagnosis of the problem?

Gitpod (cloud edition) is helpful since everyone can use a workspace on it for 50 hours / months.

### What is your fix for the problem, implemented in this PR?

Added `.gitpod.yml` but there is no pre-built image including Ruby 3.1 and Node.js so we need to prepare it by ourselves.

#### How to test
1. Visit `https://github.com/tnir/bundler-site/tree/gitpod` and click a button to launch a Gitpod workspace for this.
2. First build will take some time (5 minutes and more).

### Why did you choose this fix out of the possible options?

Added a button to launch from README.md for novice contributors. I can do it for GitHub Codespaces as well in another PR.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)