### PR TITLE
Replace rocket hashes with Ruby 1.9 ones

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ AllCops:
 
 Layout/TrailingWhitespace:
   Enabled: true
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  EnforcedShorthandSyntax: never

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
 Dir.glob("lib/tasks/**/*.rake").each { |r| load r }
 
 desc "Build the static site"
-task :build => ["contributors:update", :repo_pages, :man] do
+task build: ["contributors:update", :repo_pages, :man] do
   sh "middleman build --clean --verbose"
 end
 
 # Heroku runs assets:precompile during deploys
 namespace :assets do
-  task :precompile => :build
+  task precompile: :build
 end

--- a/config.ru
+++ b/config.ru
@@ -29,7 +29,7 @@ module Rack
 end
 
 use Rack::Deflater
-use Rack::TryStatic, :root => "build", :urls => %w[/], :try => ['.html', 'index.html', '/index.html']
+use Rack::TryStatic, root: "build", urls: %w[/], try: ['.html', 'index.html', '/index.html']
 
 # Run your own Rack app here or use this one to serve 404 messages:
 run lambda{ |env|

--- a/helpers/command_reference_helper.rb
+++ b/helpers/command_reference_helper.rb
@@ -14,10 +14,10 @@ module CommandReferenceHelper
     yield command
     partial(
       'shared/command',
-      :locals => {
-        :name => command.name,
-        :desc => command.desc,
-        :opts => command.opts
+      locals: {
+        name: command.name,
+        desc: command.desc,
+        opts: command.opts
       }
     )
   end

--- a/lib/tasks/ci/deploy.rake
+++ b/lib/tasks/ci/deploy.rake
@@ -18,7 +18,7 @@ namespace :ci do
     sh "rm deploy_key"
   end
 
-  task :deploy => [:build] do
+  task deploy: :build do
     configure_ssh_deploy_key
 
     Rake::Task["ci:update_ssh_site"].invoke

--- a/lib/tasks/ci/ssh_repo.rake
+++ b/lib/tasks/ci/ssh_repo.rake
@@ -3,7 +3,7 @@ directory "vendor/ssh_bundler.github.io" => ["vendor"] do
 end
 
 namespace :ci do
-  task :update_ssh_site => ["vendor/ssh_bundler.github.io"] do
+  task update_ssh_site: "vendor/ssh_bundler.github.io" do
     Dir.chdir "vendor/ssh_bundler.github.io" do
       sh "git checkout master"
       sh "git reset --hard HEAD"

--- a/lib/tasks/man_generator/man.rake
+++ b/lib/tasks/man_generator/man.rake
@@ -1,5 +1,5 @@
 desc "Pull in the man pages for the specified gem versions."
-task :man => [:update_vendor] do
+task man: :update_vendor do
   VERSIONS.each do |version|
     next if version == "v0.9"
 

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,5 +1,5 @@
 desc "Release the current commit to bundler/bundler.github.io"
-task :release => [:build, :update_site] do
+task release: [:build, :update_site] do
   commit = `git rev-parse HEAD`.chomp
 
   Dir.chdir "vendor/bundler.github.io" do

--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -46,13 +46,13 @@ directory "vendor/rubygems" => ["vendor"] do
   system "git clone --depth 1 --no-single-branch https://github.com/rubygems/rubygems.git vendor/rubygems"
 end
 
-task :update_vendor => ["vendor/bundler", "vendor/rubygems"] do
+task update_vendor: ["vendor/bundler", "vendor/rubygems"] do
   Dir.chdir("vendor/bundler") { sh "git fetch" }
   Dir.chdir("vendor/rubygems") { sh "git fetch" }
 end
 
 desc "Pulls in pages maintained in the bundler repo."
-task :repo_pages => [:update_vendor] do
+task repo_pages: :update_vendor do
   Dir.chdir "vendor/bundler" do
     sh "git reset --hard HEAD"
     sh "git checkout origin/master"
@@ -71,7 +71,7 @@ directory "vendor/bundler.github.io" => ["vendor"] do
   system "git clone https://github.com/bundler/bundler.github.io vendor/bundler.github.io"
 end
 
-task :update_site => ["vendor/bundler.github.io"] do
+task update_site: "vendor/bundler.github.io" do
   Dir.chdir "vendor/bundler.github.io" do
     sh "git checkout master"
     sh "git reset --hard HEAD"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Rocket hashes are used in Ruby code.

### What was your diagnosis of the problem?

They can be replaced with new ones.

### What is your fix for the problem, implemented in this PR?

Replace rocket hashes in Ruby code with Ruby 1.9 ones.

### Why did you choose this fix out of the possible options?

Simplified code would give a better contributor experience.

No other cops are not enabled in this PR as per the title.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
