### PR TITLE
Use Bundler on raken man

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or you can prepare a development environment on Gitpod cloud from the below link
 
 Fetch latest documentation from bundler repo (should be done before running local development web server):
 
-    rake man
+    bundle exec rake man
 
 Run a local development web server:
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`rake man` causes an error if you run it as shown in README.md:

```
$ rake man
git fetch
git fetch
rm -rf source/v1.12/man
mkdir -p source/v1.12/man
git reset --hard HEAD
HEAD is now at e86410c3 Version 1.12.6 with changelog
git checkout origin/1-12-stable
HEAD is now at e86410c3 Version 1.12.6 with changelog
/.../.rvm/rubies/ruby-3.1.2/bin/ruby -S ronn -5 man/*.ronn
/.../.rvm/rubies/ruby-3.1.2/bin/ruby: No such file or directory -- ronn (LoadError)
rake aborted!
Command failed with status (1): [/.../.rvm/rubies/ruby-3.1.2/bin/ru...]
lib/tasks/man_generator/man.rake:22:in `block (3 levels) in <top (required)>'
lib/tasks/man_generator/man.rake:19:in `chdir'
lib/tasks/man_generator/man.rake:19:in `block (2 levels) in <top (required)>'
lib/tasks/man_generator/man.rake:3:in `each'
lib/tasks/man_generator/man.rake:3:in `block in <top (required)>'
Tasks: TOP => man
(See full trace by running task with --trace)
```

### What was your diagnosis of the problem?

Bundler is not used while Bundler should be used to avoid such an error.

### What is your fix for the problem, implemented in this PR?

Update the instruction on README.md not to see such an error.

- Updates a tiny part of #218

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)