### PR TITLE
Remove jQuery dependency from commands layout

### DIFF
--- a/assets/javascripts/anchors.js
+++ b/assets/javascripts/anchors.js
@@ -1,8 +1,4 @@
-import $ from 'jquery'
 import AnchorJS from 'anchor-js';
 
 const anchors = new AnchorJS();
-
-$(document).ready(function() {
-  anchors.add();
-});
+anchors.add();

--- a/assets/javascripts/commands_layout.js
+++ b/assets/javascripts/commands_layout.js
@@ -1,13 +1,11 @@
-import $ from 'jquery'
 import AnchorJS from 'anchor-js';
 
 const anchors = new AnchorJS();
 
-$('.version-selects').change(function(e) {
-  document.location.href = $(e.target).find(":selected").val();
+const el = document.querySelector('.version-selects');
+el.addEventListener('input', function (e) {
+  document.location.href = e.target.value;
 });
 
-$(document).ready(function() {
-  anchors.add('#page-content-wrapper h1, #page-content-wrapper h2, #page-content-wrapper h3, ' +
-    '#page-content-wrapper h4, #page-content-wrapper h5');
-});
+anchors.add('#page-content-wrapper h1, #page-content-wrapper h2, #page-content-wrapper h3, ' +
+  '#page-content-wrapper h4, #page-content-wrapper h5');


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

An end-user has loaded unused jQuery.

- See also #653

### What was your diagnosis of the problem?

These code currently depending on jQuery can be replaced with vanilla JS.

### What is your fix for the problem, implemented in this PR?

The relevant code was simply replaced with vanilla JS.

### Why did you choose this fix out of the possible options?

Just follow the instruction from AnchorJS: https://github.com/bryanbraun/anchorjs/blob/master/README.md

HTMLs for command references were done from ones for search with Lunr.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>