### PR TITLE
Restore search for guides content

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,7 +6,7 @@ config[:current_version] = config[:versions].last
 activate :syntax
 activate :i18n
 activate :search do |search|
-  search.resources = ['index.html', "#{config[:current_version]}/", 'compatibility.html', 'conduct.html', 'contributors.html', 'older_versions.html']
+  search.resources = ['index.html', 'guides/', "#{config[:current_version]}/", 'compatibility.html', 'conduct.html', 'contributors.html', 'older_versions.html']
 
   search.index_path = 'search/lunr-index.json'
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was moving around urls at #651 broke search for guides content.

### What was your diagnosis of the problem?

My diagnosis was that after moving guides to not be version dependent, their contents are no longer indexed.

### What is your fix for the problem, implemented in this PR?

My fix is to add the new urls to the list of search resources.