### PR TITLE
Use https over http in sitemap.xml

### DIFF
--- a/source/sitemap.xml.builder
+++ b/source/sitemap.xml.builder
@@ -1,14 +1,14 @@
 xml.instruct!
 xml.urlset 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
   xml.url do
-    xml.loc 'http://bundler.io'
+    xml.loc 'https://bundler.io'
     xml.lastmod Time.now.utc.iso8601
     xml.changefreq 'weekly'
     xml.priority 1.0
   end
   sitemap.resources.select{ |resource| resource.ext == '.html' }.sort_by(&:url).each do |resource|
     xml.url do
-      xml.loc URI.join('http://bundler.io', resource.url)
+      xml.loc URI.join('https://bundler.io', resource.url)
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

While bunder.io fully supports HTTPS, `/sitemap.xml` has only `http`-based URLs.

### What was your diagnosis of the problem?

We can simply replace them with HTTPS.

### What is your fix for the problem, implemented in this PR?

Use `https` over `http` as protocol.

### Why did you choose this fix out of the possible options?

No other choice.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)