### PR TITLE
Remove duplicated code for sidebar

### DIFF
--- a/assets/stylesheets/_sidebar.scss
+++ b/assets/stylesheets/_sidebar.scss
@@ -4,58 +4,16 @@
  * Licensed under MIT (https://github.com/BlackrockDigital/startbootstrap/blob/gh-pages/LICENSE)
  */
 
-#wrapper {
-  padding-left: 0;
-  -webkit-transition: all 0.5s ease;
-  -moz-transition: all 0.5s ease;
-  -o-transition: all 0.5s ease;
-  transition: all 0.5s ease;
-}
-
-#wrapper.toggled {
-  padding-left: 270px;
-}
-
 #sidebar-wrapper {
-  z-index: 1000;
-  float: left;
-  left: 250px;
-  width: 0;
-  height: 100%;
-  margin-top: 15px;
-  margin-left: -290px;
-  padding-bottom: 20px;
   -webkit-transition: all 0.5s ease;
   -moz-transition: all 0.5s ease;
   -o-transition: all 0.5s ease;
   transition: all 0.5s ease;
-}
-
-#wrapper.toggled #sidebar-wrapper {
-  width: 250px;
-}
-
-#page-content-wrapper {
-  position: relative;
-  padding: 15px;
-}
-
-#wrapper.toggled #page-content-wrapper {
-  position: relative;
-  margin-right: -250px;
 }
 
 /* Sidebar Styles */
 
 .sidebar-nav {
-  position: relative;
-  top: 20px;
-  width: 250px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  padding-left: 30px;
-
   h4 {
     font-weight: bold;
     color: #06456A;
@@ -80,7 +38,6 @@
 
 .sidebar-nav li a {
   display: block;
-  text-decoration: none;
   color: #000;
   padding: 10px 15px;
 }
@@ -118,108 +75,8 @@
   background: none;
 }
 
-@media(min-width:768px) {
-  .sidebar-nav {
-    padding-left: 10px;
-  }
-
-  #wrapper.toggled {
-    padding-left: 0;
-  }
-
-  #sidebar-wrapper {
-    width: 250px;
-    padding-left: 10px;
-  }
-
-  #wrapper.toggled #sidebar-wrapper {
-    width: 0;
-  }
-
-  #page-content-wrapper {
-    padding: 20px 20px 20px 250px;
-    position: relative;
-  }
-
-  #wrapper.toggled #page-content-wrapper {
-    position: relative;
-    margin-right: 0;
-  }
-}
-
 .truncate-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-/* Bottom Sidebar Styles */
-
-.bottom-sidebar-nav {
-  position: relative;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-
-  h4 {
-    font-weight: bold;
-    color: #06456A;
-  }
-
-  ul {
-    padding-left: 0;
-  }
-
-  .active {
-    background-color: #DBEAF3;
-  }
-}
-
-.bottom-sidebar-nav li {
-  text-indent: 20px;
-  line-height: 40px;
-  list-style-type: none;
-}
-
-.bottom-sidebar-nav ul li:last-child hr {
-  border-top-color: #ffffff;
-}
-
-.bottom-sidebar-nav li a {
-  display: block;
-  text-decoration: none;
-  color: #000;
-}
-
-.bottom-sidebar-nav li a:hover {
-  text-decoration: none;
-  color: #000;
-  background: rgba(255,255,255,0.2);
-}
-
-.bottom-sidebar-nav li a:active,
-.bottom-sidebar-nav li a:focus {
-  text-decoration: none;
-}
-
-.bottom-sidebar-nav .separator {
-  hr {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-}
-
-.bottom-sidebar-nav > .sidebar-brand {
-  height: 65px;
-  font-size: $larger-font-size;
-  line-height: 60px;
-}
-
-.bottom-sidebar-nav > .sidebar-brand a {
-  color: #999999;
-}
-
-.bottom-sidebar-nav > .sidebar-brand a:hover {
-  color: #fff;
-  background: none;
 }

--- a/source/layouts/commands_layout.haml
+++ b/source/layouts/commands_layout.haml
@@ -14,20 +14,12 @@
       srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
       class: 'img-fluid header-padding',
       style: 'max-width: 400px;'
-  .row
-    .container
-      #wrapper
-        #sidebar-wrapper.col.d-none.d-sm-block
-          .sidebar-nav
-            = partial 'partials/commands_sidebar'
-        #page-content-wrapper.commands.contents
-          ~ yield
-        .clearfix
-
-  .row
-    .container
-      #bottom-sidebar-wrapper.d-block.d-sm-none
-        .bottom-sidebar-nav
+  .container
+    .row.flex-column.flex-md-row-reverse
+      #page-content-wrapper.col-12.col-md-9.commands.contents
+        ~ yield
+      #sidebar-wrapper.col-12.col-md-3.mt-4
+        .sidebar-nav
           = partial 'partials/commands_sidebar'
 
   = javascript_include_tag 'commands_layout.min'

--- a/source/layouts/md_guides_layout.haml
+++ b/source/layouts/md_guides_layout.haml
@@ -16,20 +16,13 @@
       srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
       class: 'img-fluid header-padding',
       style: 'max-width: 400px;'
-  .row
-    #guide-container.container
-      #wrapper
-        #sidebar-wrapper.d-none.d-sm-block
-          .sidebar-nav
-            %h4 Guides
-            = partial 'partials/guides_sidebar'
-        #page-content-wrapper.guide.contents
-          ~ yield
-
-  .row
-    .container
-      #bottom-sidebar-wrapper.d-sm-none
-        .bottom-sidebar-nav
+  .container
+    .row.flex-column.flex-md-row-reverse
+      #page-content-wrapper.col-12.col-md-9.guide.contents
+        ~ yield
+      #sidebar-wrapper.col-12.col-md-3.mt-4
+        .sidebar-nav
+          %h4 Guides
           = partial 'partials/guides_sidebar'
 
   = javascript_include_tag 'anchors.min'


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

An end-user downloads duplicated HTML and CSS parts for sidebar via their browser.

### What was your diagnosis of the problem?

We can get rid of either of them.

### What is your fix for the problem, implemented in this PR?

Remove the bottom one and make the other fully responsive along with Bootstrap 4 (#644).

### Why did you choose this fix out of the possible options?

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)