### PR TITLE
Allow users to put enter on search

### DIFF
--- a/assets/javascripts/search_arrows.js
+++ b/assets/javascripts/search_arrows.js
@@ -46,7 +46,7 @@
     };
 
     this.onEnter = function() {
-      window.location.href = this.selectedLi.find('a').attr('href');
+      window.location.href = this.selectedLi.querySelector('a').getAttribute('href');
     };
 
     this.removeActiveClass = function() {


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

An end-user cannot input Enter to visit the selected page on search after #664 due to the regression in it.

- #664

### What was your diagnosis of the problem?

To get rid of jQuery from this JS was incomplete.

### What is your fix for the problem, implemented in this PR?

Completely remove jQuery methods.

### Why did you choose this fix out of the possible options?

Needed to fix a regression...

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
