### PR TITLE
Bump Bootstrap from 4.6.1 to 5.1.3

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,8 +1,3 @@
-import 'bootstrap/js/dist/button'
-import 'bootstrap/js/dist/tooltip'
-import 'bootstrap/js/dist/popover'
-import 'bootstrap/js/dist/dropdown'
-import 'bootstrap/js/dist/collapse'
 import './search'
 import './search_arrows'
 import AnchorJS from 'anchor-js';

--- a/assets/javascripts/search.js
+++ b/assets/javascripts/search.js
@@ -1,4 +1,5 @@
 import $ from 'jquery'
+import { Popover } from 'bootstrap';
 import lunr from 'lunr'
 
 var lunrIndex = null;
@@ -41,17 +42,24 @@ $(document).ready(function() {
     };
 
     this.initializePopover = function() {
-      this.popover = this.searchInput.popover(this.POPOVER_OPTIONS).data('bs.popover');
+      this.popover = new Popover(this.searchInput, this.POPOVER_OPTIONS);
     };
 
     this.hidePopover = function() {
-      this.searchInput.popover('hide');
+      const popover = Popover.getInstance(this.searchInput);
+      popover && popover.hide();
       this.searchArrows.destroy();
     };
 
     this.showPopover = function(text) {
       this.popoverContent = this.generatePopoverContent(text);
-      this.searchInput.popover('show');
+      const popover = Popover.getInstance(this.searchInput);
+      popover.show();
+      document.querySelector(".popover-body").innerHTML = this.popoverContent;
+
+      this.popoverHandler = $(self.POPOVER_CLASS);
+      this.popoverHandler.click(function(e) { e.stopPropagation() });
+      this.searchArrows.init();
     };
 
     this.generatePopoverContent = function(text) {
@@ -110,11 +118,6 @@ $(document).ready(function() {
         if (text === '') return;
         
         self.showPopover(text);
-      });
-      this.searchInput.on('shown.bs.popover', function()  {
-        self.popoverHandler = $(self.POPOVER_CLASS);
-        self.popoverHandler.click(function(e) { e.stopPropagation() });
-        self.searchArrows.init();
       });
       this.searchInput.click(function(e) { e.stopPropagation() });
       $(window).click(function() { self.hidePopover() });

--- a/assets/stylesheets/_bootstrap-overrides.scss
+++ b/assets/stylesheets/_bootstrap-overrides.scss
@@ -1,8 +1,6 @@
-$theme-colors: (
-  // for .btn-primary. This color is applied to $link-color so tweak is followed.
-  // - Discussion: https://github.com/rubygems/bundler-site/pull/644#issuecomment-1178722939
-  "primary": #12AEE2
-);
+// for .btn-primary. This color is applied to $link-color so tweak is followed.
+// - Discussion: https://github.com/rubygems/bundler-site/pull/644#issuecomment-1178722939
+$primary: #12AEE2;
 
 // navbar
 $navbar-padding-y: 0;
@@ -34,3 +32,19 @@ $card-border-width: 0;
 // Transition workaround for unifying link color and button (btn-primary) in Boostrap 4.6.1
 $link-color: #337ab7;
 // /Transition workaround
+
+// Transition workaround for text-decoration: underline only for a:hover in Boostrap 5.0
+$link-decoration: none;
+$link-hover-decoration: underline;
+// /Transition workaround
+
+// Bootstrap 5 would suggest `color:#000` for `.btn-primary`/`.btn-primary:hover`
+// by default when `$primary: #12AEE2;` as it violates "WCAG 2.1 text color
+// contrast ratio of 4.5:1" if it is `color: #fff`.
+// https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=12AEE2 (2.56:1) (.btn-primary)
+// https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=0F94C0 (3.48:1) (.btn-primary:hover)
+//
+// Upstream change: https://github.com/twbs/bootstrap/pull/30168
+//
+// cf. https://stackoverflow.com/questions/65170317/sass-scss-bootstrap-5-color-functions-not-working-well
+$min-contrast-ratio: 2.55;

--- a/assets/stylesheets/_guide.scss
+++ b/assets/stylesheets/_guide.scss
@@ -8,9 +8,3 @@
     margin-bottom: 20px;
   }
 }
-
-#guide-container {
-  .container {
-    width: auto !important;
-  }
-}

--- a/assets/stylesheets/_opacity.scss
+++ b/assets/stylesheets/_opacity.scss
@@ -1,12 +1,4 @@
 // https://getbootstrap.com/docs/5.1/utilities/colors/#opacity
-// See also
-// https://github.com/twbs/bootstrap/blob/v5.1.3/scss/_utilities.scss#L27-L39
-// https://github.com/twbs/bootstrap/blob/v5.1.3/scss/mixins/_utilities.scss#L64-L72
-.text-opacity-50 {
-  --bs-text-opacity: 0.5;
-  color: rgba($body-color, var(--bs-text-opacity));
-}
-
 // Transition workaround for skipping improvement from Bootstrap 3.4.1 to Bootstrap 4.6.1
 // - Discussion: https://github.com/rubygems/bundler-site/pull/644#issuecomment-1178722939
 .text-opacity-40 {

--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -8,6 +8,9 @@ $navbar-height: 50px;
   src: url('fonts/SancoaleSlabNormRegular.otf') format("opentype");
 }
 
+// Boostrap 5 customization
+// Document: https://getbootstrap.com/docs/5.2/customize/sass/#importing
+// List of SCSS to load: https://github.com/twbs/bootstrap/blob/v5.1.3/scss/bootstrap.scss
 @import "~bootstrap/scss/functions";
 
 pre {
@@ -23,33 +26,35 @@ $pre-color: #fff;
 
 $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 
-// Core variables and mixins
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
-// Reset and dependencies
+@import "~bootstrap/scss/utilities";
+
+// Layout & components
+// Note: tables, dropdown, button-group, accordion, breadcrumb, pagination,
+// badge, alert, progress, list-group, close, toasts, modal, tooltip, carousel,
+// spinners, offcanvas, and placeholders were excluded as they are not used as
+// of Bootstrap 5.1.3
+@import "~bootstrap/scss/root";
 @import "~bootstrap/scss/reboot";
-// Core CSS
 @import "~bootstrap/scss/type";
-@import "~bootstrap/scss/code";
+@import "~bootstrap/scss/images";
+@import "~bootstrap/scss/containers";
 @import "~bootstrap/scss/grid";
-@import "~bootstrap/scss/tables";
 @import "~bootstrap/scss/forms";
 @import "~bootstrap/scss/buttons";
 @import "~bootstrap/scss/transitions";
-// Components
-@import "~bootstrap/scss/dropdown";
 @import "~bootstrap/scss/nav";
 @import "~bootstrap/scss/navbar";
-@import "~bootstrap/scss/pagination";
-@import "~bootstrap/scss/media";
-@import "~bootstrap/scss/code";
-@import "~bootstrap/scss/images";
-// Utility classes
-@import "~bootstrap/scss/utilities";
-
-@import "~bootstrap/scss/modal";
-@import "~bootstrap/scss/tooltip";
+@import "~bootstrap/scss/card";
 @import "~bootstrap/scss/popover";
+
+// Helpers
+@import "~bootstrap/scss/helpers";
+
+// Utilities
+@import "~bootstrap/scss/utilities/api";
+// end of Boostrap 5 customization
 
 @import "navbar";
 @import "docs";
@@ -61,7 +66,7 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 @import "anchorjs";
 @import "search";
 
-// Utilities from Bootstrap 5.x
+// More various utilities extended from Bootstrap 5.1
 @import "opacity";
 
 .row:after {
@@ -98,9 +103,6 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
     float: none !important;
   }
 
-  .center-on-xs {
-    text-align: center;
-  }
 }
 
 .content-padding {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@popperjs/core": "^2.11.5",
         "anchor-js": "^4.3.1",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^5.1.3",
         "jquery": "^3.6.0",
         "lunr": "^0.7.0"
       },
@@ -205,6 +206,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -752,16 +762,15 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.10.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2697,17 +2706,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.4",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.4.tgz",
@@ -4124,6 +4122,11 @@
         "rimraf": "^3.0.2"
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -4591,9 +4594,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "requires": {}
     },
     "brace-expansion": {
@@ -6093,12 +6096,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "peer": true
     },
     "postcss": {
       "version": "8.4.4",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
+    "@popperjs/core": "^2.11.5",
     "anchor-js": "^4.3.1",
-    "bootstrap": "^4.6.1",
+    "bootstrap": "^5.1.3",
     "jquery": "^3.6.0",
     "lunr": "^0.7.0"
   }

--- a/source/contributors.html.haml
+++ b/source/contributors.html.haml
@@ -2,7 +2,7 @@
 title: Contributors
 ---
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/team_header_transparent_bg.png',
     srcset: '/images/team_header_transparent_bg.png 1x, /images/team_header_transparent_bg@2x.png 2x, /images/team_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -1,14 +1,15 @@
 %link{rel: "stylesheet", href: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css", integrity: "sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==", crossorigin: "anonymous", referrerpolicy: "no-referrer"}
-%nav.navbar.navbar-expand-md.navbar-light.container-md.justify-content-between
-  = link_to 'Bundler', '/', class: "navbar-brand mr-auto font-weight-bold"
-  %button.navbar-toggler{type: "button", "data-toggle": "collapse", "data-target": "#bs-navbar-collapse", "aria-controls": "bs-navbar-collapse", "aria-expanded": "false", "aria-label": "Toggle navigation"}
-    %span.navbar-toggler-icon
-  .collapse.navbar-collapse.flex-grow-0#bs-navbar-collapse
-    %ul.nav.navbar-nav
-      %li.nav-item
-        %input#input-search.input-search.my-1.pl-1.pt-1{type: :text, placeholder: t('search.placeholder')}
-        %i.fa.fa-search.text-opacity-40.px-1.py-2
-      %li.nav-item= link_to t('navbar.docs'), '/docs.html', class: "nav-link"
-      %li.nav-item= link_to t('navbar.team'), '/contributors.html', class: "nav-link"
-      %li.nav-item= link_to t('navbar.blog'), '/blog', class: "nav-link"
-      %li.nav-item= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems/tree/master/bundler', target: '_blank', rel: 'noopener noreferrer', class: "nav-link"
+%nav.navbar.navbar-expand-md.navbar-light
+  .container-md
+    = link_to 'Bundler', '/', class: "navbar-brand me-auto fw-bold"
+    %button.navbar-toggler{type: "button", "data-bs-toggle": "collapse", "data-bs-target": "#bs-navbar-collapse", "aria-controls": "bs-navbar-collapse", "aria-expanded": "false", "aria-label": "Toggle navigation"}
+      %span.navbar-toggler-icon
+    .collapse.navbar-collapse.flex-grow-0#bs-navbar-collapse
+      %ul.navbar-nav
+        %li.nav-item
+          %input#input-search.input-search.my-1.ps-1.pt-1{type: :text, placeholder: t('search.placeholder')}
+          %i.fa.fa-search.text-opacity-40.px-1.py-2
+        %li.nav-item= link_to t('navbar.docs'), '/docs.html', class: "nav-link"
+        %li.nav-item= link_to t('navbar.team'), '/contributors.html', class: "nav-link"
+        %li.nav-item= link_to t('navbar.blog'), '/blog', class: "nav-link"
+        %li.nav-item= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems/tree/master/bundler', target: '_blank', rel: 'noopener noreferrer', class: "nav-link"

--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -24,10 +24,9 @@
   %body{class: current_page.data.page_classes || ''}
     = partial 'layouts/navbar'
 
-    .main-wrapper.container-fluid
-      ~ yield
+    ~ yield
 
-      = yield_content :tail
+    = yield_content :tail
 
     .footer
       = partial 'layouts/footer'

--- a/source/layouts/commands_layout.haml
+++ b/source/layouts/commands_layout.haml
@@ -3,13 +3,13 @@
 
 ~ wrap_layout :base do
   - content_for :tail do
-    .row.bg-light-blue
+    .bg-light-blue
       .container
         .contents
           .edit-on-github.text-center
             = link_to_editable_version
 
-  .row.bg-light-blue.header
+  .bg-light-blue.header
     = image_tag '/images/docs_header_transparent_bg.png',
       srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
       class: 'img-fluid header-padding',

--- a/source/layouts/guides_layout.haml
+++ b/source/layouts/guides_layout.haml
@@ -2,20 +2,20 @@
 
 ~ wrap_layout :base do
   - content_for :tail do
-    .row.bg-light-blue
+    .bg-light-blue
       .container
         .contents
           .edit-on-github.text-center
             = link_to_editable_version
 
-  .row.bg-light-blue.header
+  .bg-light-blue.header
     = image_tag '/images/docs_header_transparent_bg.png',
       srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
       class: 'img-fluid header-padding',
       style: 'max-width: 400px;'
-  .row
-    #guide-container.container
-      .col-md-12
+  .container
+    .row
+      .col-12
         ~ yield
 
   = javascript_include_tag 'anchors.min'

--- a/source/layouts/md_guides_layout.haml
+++ b/source/layouts/md_guides_layout.haml
@@ -5,13 +5,13 @@
 
 ~ wrap_layout :base do
   - content_for :tail do
-    .row.bg-light-blue
+    .bg-light-blue
       .container
         .contents
           .edit-on-github.text-center
             = link_to_editable_version
 
-  .row.bg-light-blue.header
+  .bg-light-blue.header
     = image_tag '/images/docs_header_transparent_bg.png',
       srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
       class: 'img-fluid header-padding',

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -1,78 +1,70 @@
-.row.bg-dark-blue
+.bg-dark-blue
+  .mx-auto.text-center
+    = image_tag '/images/header_transparent_bg.png',
+      srcset: '/images/header_transparent_bg.png 1x, /images/header_transparent_bg@2x.png 2x, /images/header_transparent_bg@3x.png 3x',
+      class: 'img-fluid'
+
+.container
+  .my-5.large-font
+    %p= t('home.bundler_info1')
+    %p= t('home.bundler_info2')
+
+  %p.text-center
+    = link_to t('home.what_can_bundler_do'), "./#{current_version}/#getting-started", class: 'btn btn-primary btn-lg btn-responsive'
+    = link_to "#{t("home.new_in")} #{current_version}", '/whats_new.html', class: 'btn btn-primary btn-lg btn-responsive'
+    = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg btn-responsive'
+    = link_to t('home.chat_with_us'), 'http://slack.bundler.io', class: 'btn btn-primary btn-lg btn-responsive'
+
+.bg-light-blue
   .container
-    .col-md-12
-      = image_tag '/images/header_transparent_bg.png',
-        srcset: '/images/header_transparent_bg.png 1x, /images/header_transparent_bg@2x.png 2x, /images/header_transparent_bg@3x.png 3x',
-        class: 'img-fluid'
+    %h2
+      The latest news
+    %h3
+      - blog.articles[0..0].each do |article|
+        = article.date.to_date.strftime("%b %e, %Y")
+        = link_to article.title, article.url
 
-.row.btn-margin-top
+.my-3.my-md-4.p-3
   .container
-    .col-md-12
-      .content-padding.large-font
-        %p= t('home.bundler_info1')
-        %p= t('home.bundler_info2')
+    %h2#getting-started
+      %b= t('home.getting_started')
 
-      %p.text-center
-        = link_to t('home.what_can_bundler_do'), "./#{current_version}/#getting-started", class: 'btn btn-primary btn-lg btn-responsive'
-        = link_to "#{t("home.new_in")} #{current_version}", '/whats_new.html', class: 'btn btn-primary btn-lg btn-responsive'
-        = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg btn-responsive'
-        = link_to t('home.chat_with_us'), 'http://slack.bundler.io', class: 'btn btn-primary btn-lg btn-responsive'
+    .large-font.btn-margin-top
+      .bullet
+        .description
+          %p= t('home.getting_started_description')
+        :code
+          $ gem install bundler
+      .bullet
+        .description
+          %p= t('home.getting_started_description2')
+        :code
+          # lang: ruby
+          source 'https://rubygems.org'
+          gem 'nokogiri'
+          gem 'rack', '~> 2.0.1'
+          gem 'rspec'
+        %p.text-center.text-md-end
+          = link_to t('home.learn_more_gemfile'), './gemfile.html', class: 'btn btn-primary btn-lg btn-responsive'
 
-.row.bg-light-blue
+      .bullet
+        .description
+          %p= t('home.bundle_install_description')
+        :code
+          $ bundle install
+          $ git add Gemfile Gemfile.lock
+        %p.text-center.text-md-end
+          = link_to t('home.learn_more_bundle_install'), "./#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg btn-responsive'
+
+.bg-light-blue
   .container
-    .col-md-12
-      %h2
-        The latest news
-      %h3
-        - blog.articles[0..0].each do |article|
-          = article.date.to_date.strftime("%b %e, %Y")
-          = link_to article.title, article.url
-      %br
+    %h2#get-involved Get involved
+    .large-font
+      Bundler has a lot of contributors and users, and we would love to have your help! If you have questions, join #{link_to 'the Bundler Slack', 'http://slack.bundler.io'} and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with #{link_to 'the contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you think you've found a security issue, please report it via #{link_to 'HackerOne', 'https://hackerone.com/rubygems'}.
 
-.row.btn-margin-top
-  .container
-    .col-md-12
-      %h2#getting-started
-        %b= t('home.getting_started')
-
-      .large-font.btn-margin-top
-        .bullet
-          .description
-            %p= t('home.getting_started_description')
-          :code
-            $ gem install bundler
-        .bullet
-          .description
-            %p= t('home.getting_started_description2')
-          :code
-            # lang: ruby
-            source 'https://rubygems.org'
-            gem 'nokogiri'
-            gem 'rack', '~> 2.0.1'
-            gem 'rspec'
-          %p.center-on-xs
-            = link_to t('home.learn_more_gemfile'), './gemfile.html', class: 'btn btn-primary btn-lg float-right btn-responsive'
-        .clearfix
-
-        .bullet
-          .description
-            %p= t('home.bundle_install_description')
-          :code
-            $ bundle install
-            $ git add Gemfile Gemfile.lock
-          %p.center-on-xs
-            = link_to t('home.learn_more_bundle_install'), "./#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg float-right btn-responsive'
-
-.row.bg-light-blue
-  .container
-    .col-md-12
-      %h2#get-involved Get involved
-      .large-font
-        Bundler has a lot of contributors and users, and we would love to have your help! If you have questions, join #{link_to 'the Bundler Slack', 'http://slack.bundler.io'} and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with #{link_to 'the contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you think you've found a security issue, please report it via #{link_to 'HackerOne', 'https://hackerone.com/rubygems'}.
-
-      .contents
-        .buttons
-          = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary'
-          = link_to 'Join the Bundler Slack', 'http://slack.bundler.io', class: 'btn btn-primary'
-          = link_to 'Contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary'
-          = link_to 'Report security issue', 'https://hackerone.com/rubygems', class: 'btn btn-primary'
+    .contents
+      .buttons
+        = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary'
+        = link_to 'Join the Bundler Slack', 'http://slack.bundler.io', class: 'btn btn-primary'
+        = link_to 'Contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary'
+        = link_to 'Report security issue', 'https://hackerone.com/rubygems', class: 'btn btn-primary'

--- a/source/partials/_blog_header.haml
+++ b/source/partials/_blog_header.haml
@@ -1,4 +1,4 @@
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/blog_header_transparent_bg.png',
     srcset: '/images/blog_header_transparent_bg.png 1x, /images/blog_header_transparent_bg@2x.png 2x, /images/blog_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/partials/_commands_sidebar.haml
+++ b/source/partials/_commands_sidebar.haml
@@ -1,12 +1,11 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
 %h4 Choose version
-.form-group
-  %select.version-selects.form-control
-    - versions.reverse.each do |version|
-      %option{selected: version == current_visible_version,
-                        value: documentation_path(current_page_without_version, version) || documentation_path('bundle-install.1', version)}
-        = version
+%select.version-selects.form-select.mb-3
+  - versions.reverse.each do |version|
+    %option{selected: version == current_visible_version,
+                      value: documentation_path(current_page_without_version, version) || documentation_path('bundle-install.1', version)}
+      = version
 %h4 Primary Commands
 %ul
   - primary_commands.select{ |page| path_exist?(page, current_visible_version) }.each do |page|

--- a/source/v1.12/docs.html.haml
+++ b/source/v1.12/docs.html.haml
@@ -5,7 +5,7 @@ description: Main Docs page with all available resources
 
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v1.13/docs.html.haml
+++ b/source/v1.13/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v1.14/docs.html.haml
+++ b/source/v1.14/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v1.15/docs.html.haml
+++ b/source/v1.15/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v1.16/docs.html.haml
+++ b/source/v1.16/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v1.17/docs.html.haml
+++ b/source/v1.17/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v2.0/docs.html.haml
+++ b/source/v2.0/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v2.1/docs.html.haml
+++ b/source/v2.1/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v2.2/docs.html.haml
+++ b/source/v2.2/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',

--- a/source/v2.3/docs.html.haml
+++ b/source/v2.3/docs.html.haml
@@ -1,6 +1,6 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle_help)
 
-.row.bg-light-blue.header
+.bg-light-blue.header
   = image_tag '/images/docs_header_transparent_bg.png',
     srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
     class: 'img-fluid header-padding',


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Maybe nothing.

Closes #673

- Previous update: #644

### What was your diagnosis of the problem?

Newer library might cause faster page rendering.

### What is your fix for the problem, implemented in this PR?

- Update Bootstrap from 4.6.1 to 5.1.3.
- `.row` classnames were removed at a bare minimum.

### Why did you choose this fix out of the possible options?

Bootstrap 4.6 would be EOL'd sometime in the near future.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)