### PR TITLE
Remove imports-loader as it is now not required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
       },
       "devDependencies": {
         "css-loader": "^5.2.0",
-        "imports-loader": "^4.0.0",
         "mini-css-extract-plugin": "^2.6.1",
         "node-sass": "^7.0.1",
         "sass-loader": "^13.0.2",
@@ -1694,26 +1693,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/imports-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-4.0.0.tgz",
-      "integrity": "sha512-8PPbhk/9CEHd0WWKESw/oYTDhp3So9PWA9OfyIbH3kywIN4uxrWkQ8ux47xpk4yWUKX97Erbws9MFSaBlVvAjg==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.6.1",
-        "strip-comments": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -3449,15 +3428,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
-      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/strip-indent": {
@@ -5318,16 +5288,6 @@
         "resolve-cwd": "^3.0.0"
       }
     },
-    "imports-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-4.0.0.tgz",
-      "integrity": "sha512-8PPbhk/9CEHd0WWKESw/oYTDhp3So9PWA9OfyIbH3kywIN4uxrWkQ8ux47xpk4yWUKX97Erbws9MFSaBlVvAjg==",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.6.1",
-        "strip-comments": "^2.0.1"
-      }
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6658,12 +6618,6 @@
       "requires": {
         "ansi-regex": "^5.0.1"
       }
-    },
-    "strip-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
-      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
-      "dev": true
     },
     "strip-indent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/rubygems/bundler-site#readme",
   "devDependencies": {
     "css-loader": "^5.2.0",
-    "imports-loader": "^4.0.0",
     "mini-css-extract-plugin": "^2.6.1",
     "node-sass": "^7.0.1",
     "sass-loader": "^13.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,19 +37,6 @@ module.exports = {
           loader: 'url-loader?name=fonts/[name].[ext]',
         }
       },
-      {
-        test: /bootstrap\/(transition|button|tooltip|popover|dropdown|collapse)\.js$/,
-        use: [
-          {
-            loader: 'imports-loader',
-            options: {
-              imports: [
-                'default jquery jQuery'
-              ]
-            }
-          }
-        ]
-      }
     ]
   },
   plugins: [


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`imports-loader` is not required for `bootstrap@4` or did not look required for `bootstrap-sass`.

### What was your diagnosis of the problem?

We need to follow up #562. Commit message in #562 explains:

> * `imports-loader` to inject the code to make jquery globals available into bootstrap-sass.

### What is your fix for the problem, implemented in this PR?

Just remove use of imports-loader and dependency of it.

### Why did you choose this fix out of the possible options?

While I am not sure if Bootstrap 3 (or bootstrap-sass) requires it, it is obvious there is no reference to imports-loader after #644.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)