### PR TITLE
Remove orphan /older_versions.html

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,7 +6,7 @@ config[:current_version] = config[:versions].last
 activate :syntax
 activate :i18n
 activate :search do |search|
-  search.resources = ['index.html', 'guides/', "#{config[:current_version]}/", 'compatibility.html', 'conduct.html', 'contributors.html', 'older_versions.html']
+  search.resources = ['index.html', 'guides/', "#{config[:current_version]}/", 'compatibility.html', 'conduct.html', 'contributors.html']
 
   search.index_path = 'search/lunr-index.json'
 
@@ -136,7 +136,6 @@ end
 redirect "sponsors.html", to: "https://rubygems.org/pages/sponsors" # Backwards compatibility
 
 page '/conduct.html', layout: :guides_layout
-page '/older_versions.html', layout: :guides_layout
 page '/compatibility.html', layout: :guides_layout
 page /\/v(\d+.\d+)\/(?!bundle_|commands|docs|man)(.*)/, layout: :md_guides_layout
 page /\/v(.*)\/bundle_(.*)/, layout: :commands_layout
@@ -151,6 +150,7 @@ page '/sitemap.xml', layout: false
 
 redirect "issues.html", to: "doc/contributing/issues.html" # Backwards compatibility
 redirect "commands.html", to: "man/bundle.1.html" # Backwards compatibility
+redirect "older_versions.html", to: "whats_new.html" # Backwards compatibility
 
 ###
 # Helpers

--- a/source/v1.12/docs.html.haml
+++ b/source/v1.12/docs.html.haml
@@ -27,7 +27,6 @@ description: Main Docs page with all available resources
         %li= link_to 'Sharing', "/#{current_visible_version}/bundler_sharing.html"
         %li= link_to 'Updating Gems', "/#{current_visible_version}/updating_gems.html"
         %li= link_to 'Compatibility', '/compatibility.html'
-        %li= link_to 'Older Versions', '/older_versions.html'
         %li= link_to 'View FAQ', "/#{current_visible_version}/faq.html"
         %li= link_to 'Troubleshooting Guide', '/doc/contributing/issues.html'
 

--- a/source/v1.13/docs.html.haml
+++ b/source/v1.13/docs.html.haml
@@ -22,7 +22,6 @@
         %li= link_to 'Sharing', "/#{current_visible_version}/bundler_sharing.html"
         %li= link_to 'Updating Gems', "/#{current_visible_version}/updating_gems.html"
         %li= link_to 'Compatibility', '/compatibility.html'
-        %li= link_to 'Older Versions', '/older_versions.html'
         %li= link_to 'View FAQ', "/#{current_visible_version}/faq.html"
 
       %h4

--- a/source/v1.14/docs.html.haml
+++ b/source/v1.14/docs.html.haml
@@ -22,7 +22,6 @@
         %li= link_to 'Sharing', "/#{current_visible_version}/bundler_sharing.html"
         %li= link_to 'Updating Gems', "/#{current_visible_version}/updating_gems.html"
         %li= link_to 'Compatibility', '/compatibility.html'
-        %li= link_to 'Older Versions', '/older_versions.html'
         %li= link_to 'View FAQ', "/#{current_visible_version}/faq.html"
 
       %h4


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

/older_versions.html is no more useful to end-users.

Closes #686

### What was your diagnosis of the problem?

Removal and redirection look better.

### What is your fix for the problem, implemented in this PR?

The file was removed and `/older_versions.html` will be redirected to `/whats_new.html`.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
