### PR TITLE
Add redirection rules for removed pages in PR 671

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -122,6 +122,10 @@ end
   redirect "v#{version}/guides/sinatra.html", to: "guides/sinatra.html"
   redirect "v#{version}/guides/updating_gems.html", to: "guides/updating_gems.html"
 
+  %w[bundler_workflow gemfile gemfile_ruby rationale rubygems rubymotion].each do |filename|
+    redirect "v#{version}/#{filename}.html", to: "guides/#{filename}.html"
+  end
+
   # Redirect old localizable guides (v1.16-v2.3) to the current (version-independent) guide
   ["", "pl/"].each do |lang|
     redirect "#{lang}v#{version}/guides/creating_gem.html", to: "#{lang}guides/creating_gem.html"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In `/v\d+\.\d+/{bundler_workflow,gemfile,gemfile_ruby,rationale,rubygems,rubymotion}.html`, 404 errors came to happen after making more docs version-independent in #671.

### What was your diagnosis of the problem?

In #671, I did not add redirection rules for deleted pages 🙏 and static links to them were not updated 🙏 .

### What is your fix for the problem, implemented in this PR?

This PR added redirections for these deleted URLs.

### Why did you choose this fix out of the possible options?

Redirections are necessary for search engine (SEO) as well as for end-users. Updating static links in HAML is deferred in another PR.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
