### PR TITLE
Replace Font Awesome with in-place SVG element for searchbox

### DIFF
--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -1,4 +1,3 @@
-%link{rel: "stylesheet", href: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css", integrity: "sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==", crossorigin: "anonymous", referrerpolicy: "no-referrer"}
 %nav.navbar.navbar-expand-md.navbar-light
   .container-md
     = link_to 'Bundler', '/', class: "navbar-brand me-auto fw-bold"
@@ -8,7 +7,9 @@
       %ul.navbar-nav
         %li.nav-item
           %input#input-search.input-search.my-1.ps-1.pt-1{type: :text, placeholder: t('search.placeholder')}
-          %i.fa.fa-search.text-opacity-40.px-1.py-2
+          %svg.text-opacity-40.m-1.mb-2{xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 512 512", style: "width: 1rem; height: 1rem; fill: currentcolor;"}
+            / Font Awesome Free 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.
+            %path{d: "M500.3 443.7l-119.7-119.7c27.22-40.41 40.65-90.9 33.46-144.7C401.8 87.79 326.8 13.32 235.2 1.723C99.01-15.51-15.51 99.01 1.724 235.2c11.6 91.64 86.08 166.7 177.6 178.9c53.8 7.189 104.3-6.236 144.7-33.46l119.7 119.7c15.62 15.62 40.95 15.62 56.57 0C515.9 484.7 515.9 459.3 500.3 443.7zM79.1 208c0-70.58 57.42-128 128-128s128 57.42 128 128c0 70.58-57.42 128-128 128S79.1 278.6 79.1 208z"}
         %li.nav-item= link_to t('navbar.docs'), '/docs.html', class: "nav-link"
         %li.nav-item= link_to t('navbar.team'), '/contributors.html', class: "nav-link"
         %li.nav-item= link_to t('navbar.blog'), '/blog', class: "nav-link"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

2 extra HTTP requests happen after #644:

- CSS (11 kB) `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css`
- Font (79 kB) `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/webfonts/fa-solid-900.woff2`

Closes #696

### What was your diagnosis of the problem?

We can replace the element (`%i.fa.fa-search`) and asset loads (CSS and Font; ~ 90 kB in total) with an in-place SVG element (~ 0.7kB).

### What is your fix for the problem, implemented in this PR?

- Removes the element (`%i.fa.fa-search`)
- Removes the asset load (`https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css`)
- Adds an in-place SVG element adapted from https://github.com/FortAwesome/Font-Awesome/blob/b452a2c086a5e3f319df61b1ce1db7d8e1ad2b7c/js-packages/%40fortawesome/fontawesome-free/svgs/solid/magnifying-glass.svg (CC BY 4.0).

#### Screenshots
##### PC (before)
![bundler io_](https://user-images.githubusercontent.com/10229505/179360200-736e9db0-49ad-4baf-9bdd-4dd52378be8e.png)
##### PC (after)
![bundler-site-tnir-in-pl-gbzeir herokuapp com_](https://user-images.githubusercontent.com/10229505/179360198-b9fe8011-a38c-4dbe-a75b-cdc5c2e2895d.png)
(note: Focusing `input` element, causing the darker blue underline, is an artifact on taking the screenshot 🙏 )
##### mobile (before)
![bundler io_(iPhone SE)](https://user-images.githubusercontent.com/10229505/179360303-3f5273b1-2aa9-4874-9e1d-44b47ebc918b.png)
##### mobile (after)
![bundler-site-tnir-in-pl-gbzeir herokuapp com_(iPhone SE)](https://user-images.githubusercontent.com/10229505/179360304-1676d9ee-26fd-457d-8c75-b90fd5e3265c.png)

### Why did you choose this fix out of the possible options?

While the adapted SVG from FA6 Free is licensed under CC BY 4.0 as per https://fontawesome.com/license/free, the license notation is left as is as follows:

```
Font Awesome Free 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.
```

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)