### PR TITLE
Replace url-loader with Webpack's Asset Modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "sass": "^1.53.0",
         "sass-loader": "^13.0.2",
         "style-loader": "^3.3.1",
-        "url-loader": "^4.1.1",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.10.0"
       }
@@ -4227,33 +4226,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-loader": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
-      "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "mime-types": "^2.1.27",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "file-loader": "*",
-        "webpack": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "file-loader": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7884,17 +7856,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-loader": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
-      "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "mime-types": "^2.1.27",
-        "schema-utils": "^3.0.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "sass": "^1.53.0",
     "sass-loader": "^13.0.2",
     "style-loader": "^3.3.1",
-    "url-loader": "^4.1.1",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,14 +28,11 @@ module.exports = {
         loader: 'style-loader',
       },
       {
-        test: /\.(woff|woff2|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        loader: 'url-loader',
-      },
-      {
         test: /\.otf$/,
-        use: {
-          loader: 'url-loader?name=fonts/[name].[ext]',
-        }
+        type: 'asset/resource',
+        generator: {
+          filename: 'font/[hash][ext][query]'
+        },
       },
     ]
   },


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Web font has been bundled by `url-loader`, which has delayed first page rendering and would make web font delivery faster with CDN than GitHub Pages.

### What was your diagnosis of the problem?

Webpack Asset Modules can be used to replace.

### What is your fix for the problem, implemented in this PR?

- `.otf` is now separated from `https://bundler.io/application.css` to an individual file as `https://bundler.io/font/e68a5a6780c1d57a2eed.otf`.
- As no woff, woff2, ttf, eot, and svg files are not bundled by Webpack, the configuration for these kind of files is also removed.
   - 1 `svg` file is linked from HAML, which has been simply copied on build by Middleman.

Updates part of #562

### Why did you choose this fix out of the possible options?

Webpack Asset Modules https://webpack.js.org/guides/asset-modules/ is considered as (relatively) modern.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)