### PR TITLE
Use font-display: swap for performance

### DIFF
--- a/assets/stylesheets/_bootstrap-overrides.scss
+++ b/assets/stylesheets/_bootstrap-overrides.scss
@@ -24,7 +24,7 @@ $navbar-toggler-font-size: 1rem;
 // .btn does not need border
 $btn-border-width: 0;
 
-$font-family-sans-serif: "SancoaleSlab", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+$font-family-sans-serif: "SancoaleSlab", Times, "Times New Roman", serif;
 
 // for contributors
 $card-border-width: 0;

--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -6,6 +6,7 @@ $navbar-height: 50px;
   font-family: SancoaleSlab;
   font-style:  normal;
   src: url('fonts/SancoaleSlabNormRegular.otf') format("opentype");
+  font-display: swap;
 }
 
 // Boostrap 5 customization


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

### What was the end-user problem that led to this PR?

Downloading the font blocks text rendering.

### What was your diagnosis of the problem?

`font-display: swap` can be used.

### What is your fix for the problem, implemented in this PR?

`font-display: swap` is applied. Fallback fonts in `font-family` were updated to be in serif, not sans-serif, which is the default of Bootstrap.

### Why did you choose this fix out of the possible options?

`swap` looks like the best value for it while `failback` is available: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display