### PR TITLE
Add links to dev guides from user guides

### DIFF
--- a/source/v2.3/docs.html.haml
+++ b/source/v2.3/docs.html.haml
@@ -16,6 +16,7 @@
       %ul.ul-padding
         - guides.each do |guide|
           %li= link_to_guide guide
+        %li= link_to "Contributing to Bundler", "/doc/readme.html"
 
     .col-md-4.offset-md-0.col-9.offset-2
       %h3


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

- #707

Also relevant to

- #691

### What was your diagnosis of the problem?

Links can be added at minimum. All developer guides, generated from the main repo, already exist on Web site.

### What is your fix for the problem, implemented in this PR?

Adds a link from the sidebar in each guide (not command references) to [the top of contribution and developer guide](https://bundler.io/doc/readme.html).

### Why did you choose this fix out of the possible options?

1. A crawler and/or a user can find the entrance of from the Bundler Web site with this minimal change.
2. We can add dev guides on `https://bundler.io/docs.html`, but I skipped it **at this moment** since they are versioned.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
