### PR TITLE
Use https in Blog feed

### DIFF
--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -1,6 +1,6 @@
 xml.instruct!
 xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
-  site_url = "http://bundler.io/"
+  site_url = "https://bundler.io/"
   xml.title "Bundler Blog"
   xml.subtitle "The latest news on Bundler"
   xml.id URI.join(site_url, blog.options.prefix.to_s)


### PR DESCRIPTION
Use https in Blog feed `https://bundler.io/blog/feed.xml`.

Closes #711

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>