### PR TITLE
Redesign blog top

### DIFF
--- a/assets/stylesheets/_blog.scss
+++ b/assets/stylesheets/_blog.scss
@@ -4,10 +4,6 @@
     margin-bottom: 45px;
   }
 
-  .title {
-    margin-bottom: 0;
-  }
-
   h2, h3, h4 {
     font-weight: bold;
     
@@ -38,10 +34,5 @@
 }
 
 .date {
-  text-align: right;
-  margin-right: 5px;
-  display: inline-block;
-  width: 100px;
-  font-weight: bold;
-  color: #06456A;
+  width: 5rem;
 }

--- a/source/blog/index.html.haml
+++ b/source/blog/index.html.haml
@@ -1,26 +1,19 @@
+---
+title: Blog | Official blog for Bundler
+---
 = partial 'partials/blog_header'
 
 .container
   .row.my-5
     .col-md-12.col-xl-10.offset-xl-1
       .contents.blog
-        %h2.title
-          = link_to blog.articles.first.title, blog.articles.first.url
-        .subtitle
-          by
-          = link_to blog.articles.first.data.author, blog.articles.first.data.author_url, :target => '_blank'
-          on
-          %time
-            = blog.articles.first.date.strftime('%b %e %Y')
-        .blog-content
-          = blog.articles.first.render layout: false
+        %h1
+          The Bundler blog
 
-  .row.my-5
-    .col-md-12.col-xl-10.offset-xl-1
-      .contents.blog
-        %h1 Previous Posts
-        %ul.posts
-          - blog.articles[1..-1].each do |article|
-            %li
-              .date= article.date.to_date.strftime("%b %e, %Y")
-              = link_to article.title, article.url
+        - blog.articles.group_by { |a| a.date.strftime("%Y") }.each do |year, articles|
+          %h2= year
+          %ul.posts
+            - articles.each do |article|
+              %li.ms-2.ms-lg-4
+                .date.h3.d-block.d-md-inline-block.text-md-end.me-lg-4.me-2= article.date.to_date.strftime("%b %e")
+                = link_to article.title, article.url


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Blog top looks like the latest blog article, not home of blog.

Closes #714

### What was your diagnosis of the problem?

Simplifying it is required.

### What is your fix for the problem, implemented in this PR?

- Remove the full body of the latest article, replaced by the link to it.
- Add year sections in reverse chronological order
- Drop unused/unnecessary CSS

| PC: before | PC: after |
|-|-|
|  ![bundler io_blog_](https://user-images.githubusercontent.com/10229505/179906097-51dc9afc-c7f7-4dbd-8a40-9396f44099b1.png) | ![bundler-site-redesign-b-kwkjux herokuapp com_blog](https://user-images.githubusercontent.com/10229505/179911330-b72b3668-6617-4527-ba05-c6aae74bc2d9.png) |

| Mobile: before | Mobile: after |
|-|-|
| ![bundler io_blog_(iPhone 12 Pro)](https://user-images.githubusercontent.com/10229505/179912616-edf5043f-4afa-4505-b25d-5d9981471832.png) | ![bundler-site-redesign-b-kwkjux herokuapp com_blog(iPhone 12 Pro)](https://user-images.githubusercontent.com/10229505/179912635-7b01a66d-1f14-4fa1-acda-72d6ac536e96.png) |

### Why did you choose this fix out of the possible options?

This is a blocker of #713.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
