### PR TITLE
Copyedit Bundler v2.3 release blog article

### DIFF
--- a/source/blog/2022-01-23-bundler-v2-3.html.markdown
+++ b/source/blog/2022-01-23-bundler-v2-3.html.markdown
@@ -1,5 +1,4 @@
 ---
-
 title: "Bundler v2.3: Locking the version of Bundler itself"
 date: 2022-01-23 16:07 UTC
 tags:
@@ -90,7 +89,7 @@ All in all, we aim to provide a less surprising, less error prone and more
 consistent experience when using Bundler, and let each application be in control
 of the version that they use, and the moment that they upgrade.
 
-# What's coming next?
+## What's coming next?
 
 Future enhancements to this feature might include:
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

https://bundler.io/blog/2022/01/23/bundler-v2-3.html has a `h1` heading at the end of the article, which looks weird as other headings are all `h2` even if you want to emphasize "What's coming next?"

This would degrade search experience if we introduced a more semantic-based crawler in the future.

### What was your diagnosis of the problem?

That section can be `h2` to align with other sections in the article.

### What is your fix for the problem, implemented in this PR?

Align that heading with other headings by changing from `h1` to `h2`.

### Why did you choose this fix out of the possible options?

Any reason may exist behind #596

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

