### PR TITLE
Enable Layout/ArgumentAlignment cop in RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,14 @@
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   DisabledByDefault: true
+  Exclude:
+    - "bin/*"
+
+Layout/ArgumentAlignment:
+  Enabled: true
 
 Layout/TrailingWhitespace:
   Enabled: true

--- a/config.rb
+++ b/config.rb
@@ -36,10 +36,10 @@ set :markdown,
 
 # Webpack
 activate :external_pipeline,
- name: :webpack,
- command: build? ? "npm run build" : "npm run start",
- source: ".tmp/dist",
- latency: 1
+         name: :webpack,
+         command: build? ? "npm run build" : "npm run start",
+         source: ".tmp/dist",
+         latency: 1
 
 set :images_dir, 'images'
 


### PR DESCRIPTION
Enable `Layout/ArgumentAlignment` cop in RuboCop.

Partially updates #672

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)