### PR TITLE
Bump bootstrap from 5.1.3 to 5.2.0

### DIFF
--- a/assets/javascripts/search.js
+++ b/assets/javascripts/search.js
@@ -53,6 +53,7 @@ document.addEventListener('DOMContentLoaded', function () {
     this.showPopover = function (text) {
       this.popoverContent = this.generatePopoverContent(text);
       const popover = Popover.getInstance(this.searchInput);
+      popover._disposePopper();
       popover.show();
       document.querySelector('.popover-body').innerHTML = this.popoverContent;
     };

--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -11,7 +11,7 @@ $navbar-height: 50px;
 
 // Boostrap 5 customization
 // Document: https://getbootstrap.com/docs/5.2/customize/sass/#importing
-// List of SCSS to load: https://github.com/twbs/bootstrap/blob/v5.2.0-beta1/scss/bootstrap.scss
+// List of SCSS to load: https://github.com/twbs/bootstrap/blob/v5.2.0/scss/bootstrap.scss
 @import "~bootstrap/scss/functions";
 
 pre {
@@ -36,7 +36,7 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 // Note: tables, dropdown, button-group, accordion, breadcrumb, pagination,
 // badge, alert, progress, list-group, close, toasts, modal, tooltip, carousel,
 // spinners, offcanvas, and placeholders were excluded as they are not used as
-// of Bootstrap 5.2.0-beta1
+// of Bootstrap 5.2.0
 @import "~bootstrap/scss/root";
 @import "~bootstrap/scss/reboot";
 @import "~bootstrap/scss/type";

--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -11,7 +11,7 @@ $navbar-height: 50px;
 
 // Boostrap 5 customization
 // Document: https://getbootstrap.com/docs/5.2/customize/sass/#importing
-// List of SCSS to load: https://github.com/twbs/bootstrap/blob/v5.1.3/scss/bootstrap.scss
+// List of SCSS to load: https://github.com/twbs/bootstrap/blob/v5.2.0-beta1/scss/bootstrap.scss
 @import "~bootstrap/scss/functions";
 
 pre {
@@ -28,6 +28,7 @@ $pre-color: #fff;
 $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 
 @import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/maps";
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/utilities";
 
@@ -35,7 +36,7 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 // Note: tables, dropdown, button-group, accordion, breadcrumb, pagination,
 // badge, alert, progress, list-group, close, toasts, modal, tooltip, carousel,
 // spinners, offcanvas, and placeholders were excluded as they are not used as
-// of Bootstrap 5.1.3
+// of Bootstrap 5.2.0-beta1
 @import "~bootstrap/scss/root";
 @import "~bootstrap/scss/reboot";
 @import "~bootstrap/scss/type";
@@ -69,7 +70,7 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 @import "anchorjs";
 @import "search";
 
-// More various utilities extended from Bootstrap 5.1
+// More various utilities extended from Bootstrap 5.2
 @import "opacity";
 
 .row:after {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "anchor-js": "^5.0.0",
-        "bootstrap": "^5.2.0-beta1",
+        "bootstrap": "^5.2.0",
         "lunr": "^0.7.0"
       },
       "devDependencies": {
@@ -699,9 +699,9 @@
       "integrity": "sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA=="
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0-beta1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0-beta1.tgz",
-      "integrity": "sha512-6qbgs177WZEFY4SLQUq3tEHayYG80nfDmyTpdKi0MJqRMdS+HAoq24+YKfx6wf+nHY0rx8zrh477J1lFu4WzOA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
       "funding": [
         {
           "type": "github",
@@ -2695,9 +2695,9 @@
       "integrity": "sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA=="
     },
     "bootstrap": {
-      "version": "5.2.0-beta1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0-beta1.tgz",
-      "integrity": "sha512-6qbgs177WZEFY4SLQUq3tEHayYG80nfDmyTpdKi0MJqRMdS+HAoq24+YKfx6wf+nHY0rx8zrh477J1lFu4WzOA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
       "requires": {}
     },
     "braces": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "anchor-js": "^5.0.0",
-        "bootstrap": "^5.1.3",
+        "bootstrap": "^5.2.0-beta1",
         "lunr": "^0.7.0"
       },
       "devDependencies": {
@@ -699,15 +699,22 @@
       "integrity": "sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA=="
     },
     "node_modules/bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.2.0-beta1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0-beta1.tgz",
+      "integrity": "sha512-6qbgs177WZEFY4SLQUq3tEHayYG80nfDmyTpdKi0MJqRMdS+HAoq24+YKfx6wf+nHY0rx8zrh477J1lFu4WzOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
       "peerDependencies": {
-        "@popperjs/core": "^2.10.2"
+        "@popperjs/core": "^2.11.5"
       }
     },
     "node_modules/braces": {
@@ -2688,9 +2695,9 @@
       "integrity": "sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA=="
     },
     "bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "version": "5.2.0-beta1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0-beta1.tgz",
+      "integrity": "sha512-6qbgs177WZEFY4SLQUq3tEHayYG80nfDmyTpdKi0MJqRMdS+HAoq24+YKfx6wf+nHY0rx8zrh477J1lFu4WzOA==",
       "requires": {}
     },
     "braces": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "anchor-js": "^5.0.0",
-    "bootstrap": "^5.1.3",
+    "bootstrap": "^5.2.0-beta1",
     "lunr": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "anchor-js": "^5.0.0",
-    "bootstrap": "^5.2.0-beta1",
+    "bootstrap": "^5.2.0",
     "lunr": "^0.7.0"
   }
 }


### PR DESCRIPTION
Bootstarap 5.2.0 (GA) and 5.2.1 was released: https://blog.getbootstrap.com/2022/07/19/bootstrap-5-2-0/ and https://blog.getbootstrap.com/2022/09/07/bootstrap-5-2-1/

Bootstrap 5.2.1 fixed the regression introduced as below in 5.2.0.

~~As of 2022-07-25, Bootstrap 5.2.0 had a regression as below, so we cannot upgrade to 5.2.0. Hopefully we can go with 5.2.1.~~

- https://github.com/twbs/bootstrap/issues/36837
- ~~https://github.com/twbs/bootstrap/issues/36518~~
- https://github.com/twbs/bootstrap/issues/36420

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
