### PR TITLE
Introduce prettier as JS linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,15 @@ jobs:
         run: bundle exec middleman build
         env:
           NO_CONTRACTS: "true"
+
+  prettier:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm install
+      - name: Prettier JS
+        run: npx prettier --check assets/javascripts

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+singleQuote: true

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,9 +1,9 @@
-import './search'
-import './search_arrows'
+import './search';
+import './search_arrows';
 import AnchorJS from 'anchor-js';
 
 const anchors = new AnchorJS();
 
 anchors.options = {
-  visible: 'touch'
+  visible: 'touch',
 };

--- a/assets/javascripts/commands_layout.js
+++ b/assets/javascripts/commands_layout.js
@@ -7,5 +7,7 @@ el.addEventListener('input', function (e) {
   document.location.href = e.target.value;
 });
 
-anchors.add('#page-content-wrapper h1, #page-content-wrapper h2, #page-content-wrapper h3, ' +
-  '#page-content-wrapper h4, #page-content-wrapper h5');
+anchors.add(
+  '#page-content-wrapper h1, #page-content-wrapper h2, #page-content-wrapper h3, ' +
+    '#page-content-wrapper h4, #page-content-wrapper h5'
+);

--- a/assets/javascripts/search.js
+++ b/assets/javascripts/search.js
@@ -1,14 +1,14 @@
 import { Popover } from 'bootstrap';
-import lunr from 'lunr'
+import lunr from 'lunr';
 
 var lunrIndex = null;
-var lunrData  = null;
+var lunrData = null;
 var search = null;
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   var oReq = new XMLHttpRequest();
-  oReq.open("GET", "/search/lunr-index.json");
-  oReq.addEventListener("load", function () {
+  oReq.open('GET', '/search/lunr-index.json');
+  oReq.addEventListener('load', function () {
     lunrData = JSON.parse(oReq.response);
     lunrIndex = lunr.Index.load(lunrData.index);
     search = new Search();
@@ -17,8 +17,8 @@ document.addEventListener('DOMContentLoaded', function() {
   oReq.send();
 });
 
-(function() {
-  var Search = window.Search = function() {
+(function () {
+  var Search = (window.Search = function () {
     this.SEARCH_INPUT_ID = '#input-search';
     this.POPOVER_CLASS = '.popover';
     this.POPOVER_OPTIONS = {
@@ -26,36 +26,38 @@ document.addEventListener('DOMContentLoaded', function() {
       container: 'body',
       placement: 'bottom',
       trigger: 'manual',
-      content: (function() { return search.getPopoverContent() })
+      content: function () {
+        return search.getPopoverContent();
+      },
     };
     this.LIMIT_RESULTS = 10;
     this.popoverContent = '';
     this.popoverHandler = null;
 
-    this.processText = function(text) {
+    this.processText = function (text) {
       if (!text || text === '') return this.hidePopover();
 
       this.showPopover(text);
     };
 
-    this.initializePopover = function() {
+    this.initializePopover = function () {
       this.popover = new Popover(this.searchInput, this.POPOVER_OPTIONS);
     };
 
-    this.hidePopover = function() {
+    this.hidePopover = function () {
       const popover = Popover.getInstance(this.searchInput);
       popover && popover.hide();
       this.searchArrows.destroy();
     };
 
-    this.showPopover = function(text) {
+    this.showPopover = function (text) {
       this.popoverContent = this.generatePopoverContent(text);
       const popover = Popover.getInstance(this.searchInput);
       popover.show();
-      document.querySelector(".popover-body").innerHTML = this.popoverContent;
+      document.querySelector('.popover-body').innerHTML = this.popoverContent;
     };
 
-    this.generatePopoverContent = function(text) {
+    this.generatePopoverContent = function (text) {
       var results = lunrIndex.search(text);
       if (!results.length) return 'No results found';
 
@@ -63,17 +65,17 @@ document.addEventListener('DOMContentLoaded', function() {
       var uniqueResults = this.uniqueResults(results);
 
       var generated = '<ul class="search-list-ul">';
-      uniqueResults.forEach(function(res) {
+      uniqueResults.forEach(function (res) {
         var store = lunrData.docs[res.ref];
 
         // title
-        var title = document.createElement('h4')
+        var title = document.createElement('h4');
         title.textContent = store.title;
         var titleLink = document.createElement('a');
         titleLink.href = store.url;
         titleLink.appendChild(title);
         var li = document.createElement('li');
-        li.className = "search-list-li";
+        li.className = 'search-list-li';
         li.appendChild(titleLink);
         li.appendChild(document.createElement('br'));
 
@@ -89,17 +91,17 @@ document.addEventListener('DOMContentLoaded', function() {
         liSep.className = 'separator';
         liSep.appendChild(document.createElement('hr'));
 
-        generated += [li, liSep].map(el => el.outerHTML).join("");
+        generated += [li, liSep].map((el) => el.outerHTML).join('');
       });
 
       return generated + '</ul>';
     };
 
-    this.uniqueResults = function(results) {
+    this.uniqueResults = function (results) {
       var uniqueResults = [];
       var titles = [];
       [].forEach.call(results, function (el) {
-        if(titles.indexOf(lunrData.docs[el.ref].title) === -1) {
+        if (titles.indexOf(lunrData.docs[el.ref].title) === -1) {
           titles.push(lunrData.docs[el.ref].title);
           uniqueResults.push(el);
         }
@@ -107,40 +109,44 @@ document.addEventListener('DOMContentLoaded', function() {
       return uniqueResults;
     };
 
-    this.initializePopoverEvents = function() {
+    this.initializePopoverEvents = function () {
       var self = this;
 
-      this.searchInput.addEventListener('keydown', function(e) {
-        if (e.which == 27)  return self.hidePopover(); // esc key
+      this.searchInput.addEventListener('keydown', function (e) {
+        if (e.which == 27) return self.hidePopover(); // esc key
       });
-      this.searchInput.addEventListener('input', function(e) {
+      this.searchInput.addEventListener('input', function (e) {
         var text = this.value;
         self.processText(text);
       });
-      this.searchInput.addEventListener('focus', function(e)  {
+      this.searchInput.addEventListener('focus', function (e) {
         var text = this.value;
         if (text === '') return;
-        
+
         self.showPopover(text);
       });
-      this.searchInput.addEventListener('shown.bs.popover', function() {
+      this.searchInput.addEventListener('shown.bs.popover', function () {
         self.popoverHandler = document.querySelector(self.POPOVER_CLASS);
-        self.popoverHandler.addEventListener("click", function(e) { e.stopPropagation() });
+        self.popoverHandler.addEventListener('click', function (e) {
+          e.stopPropagation();
+        });
         self.searchArrows.init();
       });
-      this.searchInput.addEventListener("click", function(e) { e.stopPropagation() });
-      window.addEventListener("click", self.hidePopover.bind(self));
+      this.searchInput.addEventListener('click', function (e) {
+        e.stopPropagation();
+      });
+      window.addEventListener('click', self.hidePopover.bind(self));
     };
-  };
+  });
 
-  Search.prototype.init = function()  {
+  Search.prototype.init = function () {
     this.searchInput = document.querySelector(this.SEARCH_INPUT_ID);
     this.searchArrows = new SearchArrows();
     this.initializePopoverEvents();
     this.initializePopover();
   };
 
-  Search.prototype.getPopoverContent = function() {
+  Search.prototype.getPopoverContent = function () {
     return this.popoverContent;
   };
 })();

--- a/assets/javascripts/search_arrows.js
+++ b/assets/javascripts/search_arrows.js
@@ -1,30 +1,32 @@
-(function() {
-  var SearchArrows = window.SearchArrows = function() {
+(function () {
+  var SearchArrows = (window.SearchArrows = function () {
     this.LI_SELECTOR = '.search-list-li';
     this.ACTIVE_CLASS = 'active';
     this.active = false;
     this.currentSelection = null;
     this.selectedLi = null;
 
-    this.onKeydown = function(e)  {
-      if (e.which === 40)  {
+    this.onKeydown = function (e) {
+      if (e.which === 40) {
         e.preventDefault();
         this.onDownArrow();
       } else if (e.which === 38) {
         e.preventDefault();
         this.onUpArrow();
-      } else if (e.which === 13)  {
+      } else if (e.which === 13) {
         this.onEnter(e);
       }
     };
     this.onKeydownCb = this.onKeydown.bind(this);
 
-    this.onUpArrow = function() {
+    this.onUpArrow = function () {
       this.removeActiveClass();
 
-      if (this.currentSelection === 0 || this.currentSelection == null) this.markLastItem();
-      else  {
-        if (this.currentSelection === 0) this.currentSelection = this.listLength - 1;
+      if (this.currentSelection === 0 || this.currentSelection == null)
+        this.markLastItem();
+      else {
+        if (this.currentSelection === 0)
+          this.currentSelection = this.listLength - 1;
         else this.currentSelection -= 1;
 
         this.selectedLi = this.list[this.currentSelection];
@@ -32,12 +34,17 @@
       }
     };
 
-    this.onDownArrow = function() {
+    this.onDownArrow = function () {
       this.removeActiveClass();
 
-      if (this.currentSelection === this.listLength - 1 || this.currentSelection == null) this.markFirstItem();
-      else  {
-        if (this.currentSelection === this.listLength - 1) this.currentSelection = 0;
+      if (
+        this.currentSelection === this.listLength - 1 ||
+        this.currentSelection == null
+      )
+        this.markFirstItem();
+      else {
+        if (this.currentSelection === this.listLength - 1)
+          this.currentSelection = 0;
         else this.currentSelection += 1;
 
         this.selectedLi = this.list[this.currentSelection];
@@ -45,28 +52,30 @@
       }
     };
 
-    this.onEnter = function() {
-      window.location.href = this.selectedLi.querySelector('a').getAttribute('href');
+    this.onEnter = function () {
+      window.location.href = this.selectedLi
+        .querySelector('a')
+        .getAttribute('href');
     };
 
-    this.removeActiveClass = function() {
+    this.removeActiveClass = function () {
       if (this.selectedLi) this.selectedLi.classList.remove(this.ACTIVE_CLASS);
     };
 
-    this.markFirstItem = function() {
+    this.markFirstItem = function () {
       this.selectedLi = this.list[0];
       this.selectedLi.classList.add(this.ACTIVE_CLASS);
       this.currentSelection = 0;
     };
 
-    this.markLastItem = function()  {
+    this.markLastItem = function () {
       this.selectedLi = this.list[this.list.length - 1];
       this.selectedLi.classList.add(this.ACTIVE_CLASS);
       this.currentSelection = this.listLength - 1;
     };
-  };
+  });
 
-  SearchArrows.prototype.init = function()  {
+  SearchArrows.prototype.init = function () {
     if (this.isActive()) this.destroy();
 
     this.list = document.querySelectorAll(this.LI_SELECTOR);
@@ -77,17 +86,17 @@
     this.active = true;
   };
 
-  SearchArrows.prototype.destroy = function() {
+  SearchArrows.prototype.destroy = function () {
     window.removeEventListener('keydown', this.onKeydownCb);
     this.active = false;
     this.currentSelection = null;
   };
-  
-  SearchArrows.prototype.isActive = function()  {
+
+  SearchArrows.prototype.isActive = function () {
     return this.active;
   };
 
-  SearchArrows.prototype.isOneOfKeys = function(keyCode) {
-    return ([40, 38, 13].indexOf(keyCode) !== -1);
-  }
+  SearchArrows.prototype.isOneOfKeys = function (keyCode) {
+    return [40, 38, 13].indexOf(keyCode) !== -1;
+  };
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "css-loader": "^6.7.1",
         "mini-css-extract-plugin": "^2.6.1",
+        "prettier": "2.7.1",
         "sass": "^1.53.0",
         "sass-loader": "^13.0.2",
         "style-loader": "^3.3.1",
@@ -1382,6 +1383,21 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -2949,6 +2965,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   },
   "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "npx webpack --bail --mode production",
+    "lint": "prettier --check assets/javascripts",
     "start": "npx webpack -d source-map --progress --color",
-    "build": "npx webpack --bail --mode production"
+    "test": "npm run lint"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "css-loader": "^6.7.1",
     "mini-css-extract-plugin": "^2.6.1",
+    "prettier": "2.7.1",
     "sass": "^1.53.0",
     "sass-loader": "^13.0.2",
     "style-loader": "^3.3.1",


### PR DESCRIPTION
## Contributor problem

JavaScript files are not so consistent.

### What was your diagnosis of the problem?

Any linter for JavaScript files is not setup yet.

### What is your fix for the problem, implemented in this PR?

Introduce prettier as a linter for JavaScript files.

### Why did you choose this fix out of the possible options?

`singleQuote` looks preferred unlike [Prettier default](https://prettier.io/docs/en/options.html#quotes), so `singleQuote` is set `true` in this PR at this moment.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)