### PR TITLE
Remove .truncate-text from CSS

### DIFF
--- a/assets/stylesheets/_sidebar.scss
+++ b/assets/stylesheets/_sidebar.scss
@@ -74,9 +74,3 @@
   color: #fff;
   background: none;
 }
-
-.truncate-text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}


### PR DESCRIPTION
`.truncate-text` was introduced in #231, but this has not been used for 5 years after #322 removed the last reference.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)