### PR TITLE
Remove status checks from Gitpod prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,3 +8,6 @@ tasks:
       bundle install
       npm install
     command: bundle exec middleman server
+github:
+  prebuilds:
+    addCheck: false


### PR DESCRIPTION
Removes one of status checks from Gitpod prebuild as it takes a longer time than others and Gitpod prebuild is not mandatory at this moment.

Updates #648

- #648
- https://www.gitpod.io/docs/references/gitpod-yml#prebuildsaddcheck

![739](https://user-images.githubusercontent.com/10229505/180627146-abe71430-4faf-44f7-8066-cd382d56c0f3.png)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)