### PR TITLE
Pin ruby-version to 3.1.2 only without matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,13 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        ruby: ['3.1.2']
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '3.1.2'
           bundler-cache: true # 'bundle install' and cache
 
       - name: Install Node.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,13 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        ruby: ['3.1.2']
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '3.1.2'
           bundler-cache: true # 'bundle install' and cache
 
       - name: Install Node.js


### PR DESCRIPTION
This Web site is not a library and is expected to run with only a single Ruby version specified in `/.ruby-version`. The matrix has been introduced in #518 for a different purpose from the expectation. However, the original purpose was resolved in #558, but #558 missed this removal.

This will help us see GitHub status checks in pull requests since it becomes shorter.

Follows up #558

Updates #518

### before

![before-740](https://user-images.githubusercontent.com/10229505/180634488-8568097b-38b7-46b8-a1a5-ec6e36559879.png)

### after
(The section `prettier` is not relevant)

![after-740](https://user-images.githubusercontent.com/10229505/180634506-06de68e5-b947-48b6-958d-b4e851257b18.png)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)