### PR TITLE
Remove page rule for deleted /v:ver/commands.html pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -166,7 +166,6 @@ page /\/v(\d+.\d+)\/(?!bundle_|commands|docs|man)(.*)/, layout: :md_guides_layou
 page /\/v(.*)\/bundle_(.*)/, layout: :commands_layout
 page /\/v(.*)\/man\/(.*)/, layout: :commands_layout
 page /\/man\/(.*)/, layout: :commands_layout
-page /\/v(.*)\/commands\.html/, layout: :commands_layout
 page /\/v(.*)\/guides\/(.*)/, layout: :md_guides_layout
 page /guides\/(.*)/, layout: :md_guides_layout
 page /\/doc\/(.*)/, layout: :md_guides_layout # Imported from bundler/bundler


### PR DESCRIPTION
In #604, `commands.html.haml`s were deleted, but the rule for these files in Middleman was not. (cf. #536)

Follows up #604

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)