### PR TITLE
Split rake tasks into deploy and purge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,3 +30,6 @@ jobs:
         env:
           encrypted_key: ${{ secrets.encrypted_key }}
           encrypted_iv: ${{ secrets.encrypted_iv }}
+
+      - name: Purge CDN
+        run: bundle exec rake ci:clean_fastly_cache

--- a/lib/tasks/ci/deploy.rake
+++ b/lib/tasks/ci/deploy.rake
@@ -38,7 +38,5 @@ namespace :ci do
       sh "git commit -m 'rubygems/bundler-site@#{commit}'"
       sh "git push origin master"
     end
-
-    Rake::Task["ci:clean_fastly_cache"].invoke
   end
 end


### PR DESCRIPTION
Purging cache from CDN (fastly) should be separated from deploy job.

The implementation was done in #241.

Relevant to #558

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
