### PR TITLE
Remove source/layouts/layout.haml

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -18,6 +18,8 @@ activate :search do |search|
   }
 end
 
+set :layout, :base
+
 set :markdown_engine, :kramdown
 
 # Markdown extentions

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -1,2 +1,0 @@
-~ wrap_layout :base do
-  ~ yield


### PR DESCRIPTION
Closes #747

This PR focuses on removal of `source/layouts/layout.haml`, which is the default filename. In addition, the most common layout in this project `source/layouts/base.haml` has been referred from customized layout files. In another place, we may change `base` to the default name.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)