### PR TITLE
Unlock disabling zoom

### DIFF
--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -4,7 +4,7 @@
     %meta(charset="utf-8")
     %meta(http-equiv="X-UA-Compatible" content="IE=edge")
     %meta(http-equiv="Content-Language" content="#{I18n.locale.to_s}")
-    %meta(name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no")
+    %meta(name="viewport" content="width=device-width, initial-scale=1")
     %meta(name="globalsign-domain-verification" content="276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL")
     %title
       - page_title = current_page.data.title


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page.

### What was your diagnosis of the problem?

We do not need to disable zooming at all.

### What is your fix for the problem, implemented in this PR?

Remove disabling zooming  (scaling).

### Why did you choose this fix out of the possible options?

No alternative these days. See also https://web.dev/meta-viewport/ .

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
