### PR TITLE
Remove never-used CSS selectors

### DIFF
--- a/assets/stylesheets/_sidebar.scss
+++ b/assets/stylesheets/_sidebar.scss
@@ -59,18 +59,3 @@
     margin-bottom: 0;
   }
 }
-
-.sidebar-nav > .sidebar-brand {
-  height: 65px;
-  font-size: $larger-font-size;
-  line-height: 60px;
-}
-
-.sidebar-nav > .sidebar-brand a {
-  color: #999999;
-}
-
-.sidebar-nav > .sidebar-brand a:hover {
-  color: #fff;
-  background: none;
-}


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`.sidebar-brand`-related selectors were introduced in  https://github.com/rubygems/bundler-site/pull/218/commits/6ba978951705e186d2f1387932271ff5bef4806b as a part of #218.

### What was your diagnosis of the problem?

`git grep sidebar-brand` and/or `git log -p | grep sidebar-brand`

### What is your fix for the problem, implemented in this PR?

Removes all selectors including `.sidebar-brand` from `assets/stylesheets/_sidebar.scss`.

### Why did you choose this fix out of the possible options?

We cannot go back to 2016, so just do it now.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)