### PR TITLE
Append maintenance status per version

### DIFF
--- a/helpers/config_helper.rb
+++ b/helpers/config_helper.rb
@@ -6,4 +6,20 @@ module ConfigHelper
   def versions
     config[:versions]
   end
+
+  def versions_grouped_by_status
+    versions.reverse.group_by { status(_1) }
+  end
+
+  private
+
+  def status(version)
+    if version == "v2.3"
+      "Current release"
+    elsif %w[v2.2 v2.1].include?(version)
+      "Legacy release"
+    else
+      "Deprecated release"
+    end
+  end
 end

--- a/source/partials/_commands_sidebar.haml
+++ b/source/partials/_commands_sidebar.haml
@@ -2,10 +2,12 @@
 
 %h4 Choose version
 %select.version-selects.form-select.mb-3
-  - versions.reverse.each do |version|
-    %option{selected: version == current_visible_version,
-                      value: documentation_path(current_page_without_version, version) || documentation_path('bundle-install.1', version)}
-      = version
+  - versions_grouped_by_status.each do |status, _versions|
+    %optgroup{label: status}
+      - _versions.each do |version|
+        %option{selected: version == current_visible_version,
+                          value: documentation_path(current_page_without_version, version) || documentation_path('bundle-install.1', version)}
+          = version
 %h4 Primary Commands
 %ul
   - primary_commands.select{ |page| path_exist?(page, current_visible_version) }.each do |page|


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A visitor cannot see what version is active while 10 minor versions are listed.

Closes #760

### What was your diagnosis of the problem?

Looks good to start with indicating the maintenance status per version rubygems/rubygems#5647.

### What is your fix for the problem, implemented in this PR?

Append the maintenance status per version next to each version in the version selector in the versioned man pages.

| before | after |
|-|-|
| ![bundler io_v2 3_man_bundle-viz 1 html](https://user-images.githubusercontent.com/10229505/180910676-53ba6f12-5cce-470c-a85b-f5d21f2aa0d3.png) | ![v2-closed](https://user-images.githubusercontent.com/10229505/181151816-28aaa9d4-64f0-41fe-b4ec-431171fb5fbe.png) |
| ![version-selector](https://user-images.githubusercontent.com/10229505/180910692-1d15cee5-1275-40c2-9a93-1c37aa8012a7.png) | ![v2-open](https://user-images.githubusercontent.com/10229505/181151821-17f132a4-cf24-4dad-b910-c3ca0e54e24d.png) |

<details>
<summary>Previous version of screenshots after the change (only for reference)</summary>

![bundler-site-tnir-versi-phrzrh herokuapp com_v2 3_man_bundle-install 1 html](https://user-images.githubusercontent.com/10229505/180930732-01bc67be-d157-4cc3-85dd-df874b02143d.png)
![version-selector-after](https://user-images.githubusercontent.com/10229505/180930844-ff232fda-d0c2-4aa3-8fc3-0e8909e24d0a.png)
</details>

### Why did you choose this fix out of the possible options?

No other option can be imagine...

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)