### PR TITLE
Update the source of /doc and CoC as per the merger

### DIFF
--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -53,17 +53,18 @@ end
 
 desc "Pulls in pages maintained in the bundler repo."
 task repo_pages: :update_vendor do
-  Dir.chdir "vendor/bundler" do
+  Dir.chdir "vendor/rubygems/bundler" do
     sh "git reset --hard HEAD"
     sh "git checkout origin/master"
 
+    source_dir = File.expand_path("../source/", File.dirname(__dir__))
     Dir['doc/**/*.md'].each do |file|
       file_name = file[0..-4] # Removes .md suffix
-      to = File.expand_path("../../source/#{file_name}.html.md").downcase
+      to = File.expand_path("./#{file_name}.html.md", source_dir).downcase
       write_file(file, to)
     end
 
-    write_file("CODE_OF_CONDUCT.md", File.expand_path("../../source/conduct.html.md"))
+    write_file("../CODE_OF_CONDUCT.md", File.expand_path("./conduct.html.md", source_dir))
   end
 end
 

--- a/source/conduct.html.md
+++ b/source/conduct.html.md
@@ -1,4 +1,4 @@
-# Bundler Code of Conduct
+# RubyGems and Bundler Code of Conduct
 
 ## Our Pledge
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The contents updated in the upstream have not been applied to the Bundler Web site at all for more than two years.

Closes #770

### What was your diagnosis of the problem?

We should apply all changes under `/bundler/doc/**` in https://github.com/rubygems/rubygems/compare/b0c1efd...1a12bab, that is:

<details><summary><code>git diff b0c1efd...1a12bab -- bundler/doc</code></summary>

````diff
diff --git a/bundler/doc/POLICIES.md b/bundler/doc/POLICIES.md
index b10d15559..dc6a3ec57 100644
--- a/bundler/doc/POLICIES.md
+++ b/bundler/doc/POLICIES.md
@@ -72,7 +72,7 @@ Contributors who have contributed regularly for more than six months (or impleme
 
 ### Enforcement guidelines
 
-First off, Bundler's policies and enforcement of those policies are subsidiary to [Bundler's code of conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md) in any case where they conflict. The first priority is treating human beings with respect and empathy, and figuring out project guidelines and sticking to them will always come after that.
+First off, Bundler's policies and enforcement of those policies are subsidiary to [Bundler's code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) in any case where they conflict. The first priority is treating human beings with respect and empathy, and figuring out project guidelines and sticking to them will always come after that.
 
 When it comes to carrying out our own policies, we're all regular humans trying to do the best we can. There will probably be times when we don't stick to our policies or goals. If you notice a discrepancy between real-life actions and these policies and goals, please bring it up! We want to make sure that our actions and our policies line up, and that our policies exemplify our goals.
 
diff --git a/bundler/doc/README.md b/bundler/doc/README.md
index 5fe78d325..0997a352f 100644
--- a/bundler/doc/README.md
+++ b/bundler/doc/README.md
@@ -11,8 +11,8 @@ If you'd like to help make Bundler better, you totally rock! Thanks for helping
 * [Overview & getting started](contributing/README.md)
 * [How you can help: your first contributions!](contributing/HOW_YOU_CAN_HELP.md)
 * [Bug triage](contributing/BUG_TRIAGE.md)
-* [Getting help](contributing/GETTING_HELP.md)
-* [Filing issues](contributing/ISSUES.md)
+* [Getting help](https://slack.bundler.io)
+* [Filing issues](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md)
 * [Community](contributing/COMMUNITY.md)
 
 ## Development
@@ -21,10 +21,14 @@ If you'd like to help make Bundler better, you totally rock! Thanks for helping
 * [Development setup](development/SETUP.md)
 * [Submitting pull requests](development/PULL_REQUESTS.md)
 * [Adding new features](development/NEW_FEATURES.md)
-* [Releasing Bundler](development/RELEASING.md)
 
 ## Documentation
 
 * [Overview](documentation/README.md)
 * [Writing docs for man pages](documentation/WRITING.md)
 * [Documentation vision](documentation/VISION.md)
+
+## Maintainers
+
+* [Merging pull requests](playbooks/MERGING_A_PR.md)
+* [Releasing Bundler](playbooks/RELEASING.md)
diff --git a/bundler/doc/TROUBLESHOOTING.md b/bundler/doc/TROUBLESHOOTING.md
index d5ef596d3..e6ae7c38c 100644
--- a/bundler/doc/TROUBLESHOOTING.md
+++ b/bundler/doc/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting common issues
 
-Stuck using Bundler? Browse these common issues before [filing a new issue](contributing/ISSUES.md).
+Stuck using Bundler? Browse these common issues before [filing a new issue](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md).
 
 ## Permission denied when installing bundler
 
diff --git a/bundler/doc/contributing/BUG_TRIAGE.md b/bundler/doc/contributing/BUG_TRIAGE.md
index 423e51ca2..2dc65f57e 100644
--- a/bundler/doc/contributing/BUG_TRIAGE.md
+++ b/bundler/doc/contributing/BUG_TRIAGE.md
@@ -2,7 +2,7 @@
 
 Triaging is the work of processing tickets that have been opened by users. Common tasks include verifying bugs, categorizing tickets, and ensuring there's enough information to reproduce the bug for anyone who wants to try to fix it.
 
-We've created an [issues guide](ISSUES.md) to walk users through the process of how to report an issue with the Bundler project. We also have a [troubleshooting guide](../TROUBLESHOOTING.md) to diagnose common problems.
+We've created an [issue template]( https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue) to walk users through the process of how to report an issue with the Bundler project. We also have a [troubleshooting guide](../TROUBLESHOOTING.md) to diagnose common problems.
 
 Not every ticket will be a bug in Bundler's code, but open tickets usually mean that there is something we could improve to help that user. Sometimes that means writing additional documentation or making error messages clearer.
 
diff --git a/bundler/doc/contributing/COMMUNITY.md b/bundler/doc/contributing/COMMUNITY.md
index 77cb97ec6..c5d8acf0c 100644
--- a/bundler/doc/contributing/COMMUNITY.md
+++ b/bundler/doc/contributing/COMMUNITY.md
@@ -2,7 +2,7 @@
 
 Community is an important part of all we do. If you'd like to be part of the Bundler community, you can jump right in and start helping make Bundler better for everyone who uses it.
 
-It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/rubygems/bundler/issues) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/bundler).
+It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/rubygems/rubygems/issues) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/bundler).
 
 Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](https://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/rubygems/bundler-site) repository.
 
diff --git a/bundler/doc/contributing/GETTING_HELP.md b/bundler/doc/contributing/GETTING_HELP.md
deleted file mode 100644
index 1fd8eb78f..000000000
--- a/bundler/doc/contributing/GETTING_HELP.md
+++ /dev/null
@@ -1,11 +0,0 @@
-# Getting help
-
-If you have any questions after reading the documentation for contributing, please feel free to contact either [@indirect](https://github.com/indirect), [@segiddins](https://github.com/segiddins), or [@RochesterinNYC](https://github.com/RochesterinNYC). They are all happy to provide help working through your first bug fix or thinking through the problem you're trying to resolve.
-
-The best ways to get in touch are:
-
-* [Bundler Slack](https://bundler.slack.com).
-  * Not a member of the Slack? Join the Bundler team slack [here](https://slack.bundler.io/)!
-* [Bundler mailing list](https://groups.google.com/group/ruby-bundler)
-
-You may also find our guide on [filing issues](ISSUES.md) to be helpful as well!
diff --git a/bundler/doc/contributing/HOW_YOU_CAN_HELP.md b/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
index fc2d1d33e..5944b90a3 100644
--- a/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
+++ b/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
@@ -2,26 +2,25 @@
 
 If you're interested in contributing to Bundler, that's awesome! We'd love your help.
 
-If at any point you get stuck, here's how to [get in touch with the Bundler team for help](GETTING_HELP.md).
+If at any point you get stuck, here's how to [get in touch with the Bundler team for help](https://slack.bundler.io).
 
 ## First contribution suggestions
 
-We track [small bugs and features](https://github.com/rubygems/bundler/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) so that anyone who wants to help can start with something that's not too overwhelming.
+We track [small bugs and features](https://github.com/rubygems/rubygems/issues?q=is%3Aissue+is%3Aopen+label%3Abundler+label%3A%22good+first+issue%22) so that anyone who wants to help can start with something that's not too overwhelming.
 
 Generally, great ways to get started helping out with Bundler are:
 
   - using prerelease versions (run `gem install bundler --pre`)
-  - [reporting bugs you encounter or suggesting new features](https://github.com/rubygems/bundler/issues/new)
-    - see our [issues guide](ISSUES.md) for help on filing issues
+  - [reporting bugs you encounter or suggesting new features](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md)
     - see the [new features documentation](../development/NEW_FEATURES.md) for more
   - adding to or editing [the Bundler documentation website](https://bundler.io) and [Bundler man pages](https://bundler.io/man/bundle.1.html)
   - [checking issues for completeness](BUG_TRIAGE.md)
   - closing issues that are not complete
-  - adding a failing test for reproducible [reported bugs](https://github.com/rubygems/bundler/issues)
-  - reviewing [pull requests](https://github.com/rubygems/bundler/pulls) and suggesting improvements
-  - improving existing code, including suggestions from [CodeClimate](https://codeclimate.com/github/rubygems/bundler)
+  - adding a failing test for reproducible [reported bugs](https://github.com/rubygems/rubygems/issues)
+  - reviewing [pull requests](https://github.com/rubygems/rubygems/pulls) and suggesting improvements
+  - improving existing code, including suggestions from [CodeClimate](https://codeclimate.com/github/rubygems/rubygems)
   - writing code (no patch is too small! fix typos or bad whitespace)
     - get started setting up your dev environment with [these instructions](../development/SETUP.md)
-  - backfilling [unit tests](https://github.com/rubygems/bundler/tree/master/spec/bundler) for modules that lack coverage.
+  - backfilling [unit tests](https://github.com/rubygems/rubygems/tree/master/bundler/spec/bundler) for modules that lack coverage.
 
 If nothing on those lists looks good, [talk to us](https://slack.bundler.io/), and we'll figure out what you can help with. We can absolutely use your help, no matter what level of programming skill you have at the moment.
diff --git a/bundler/doc/contributing/ISSUES.md b/bundler/doc/contributing/ISSUES.md
deleted file mode 100644
index 602a9c545..000000000
--- a/bundler/doc/contributing/ISSUES.md
+++ /dev/null
@@ -1,51 +0,0 @@
-# Filing Issues: a guide
-
-So! You're having problems with Bundler. This file is here to help. If you're running into an error, try reading the rest of this file for help. If you can't figure out how to solve your problem, there are also instructions on how to report a bug.
-
-Before filing an issue, check our [troubleshooting guide](../TROUBLESHOOTING.md) for quick fixes to common issues.
-
-## Documentation
-
-Instructions for common Bundler uses can be found on the [Bundler documentation site](https://bundler.io/).
-
-Detailed information about each Bundler command, including help with common problems, can be found in the [Bundler man pages](https://bundler.io/man/bundle.1.html) or [Bundler Command Line Reference](https://bundler.io/v1.11/commands.html).
-
-## Reporting unresolved problems
-
-Check our [troubleshooting common issues guide](../TROUBLESHOOTING.md) and see if your issue is resolved using the steps provided.
-
-Hopefully the troubleshooting steps above resolved your problem! If things still aren't working the way you expect them to, please let us know so that we can diagnose and hopefully fix the problem you're having.
-
-**The best way to report a bug is by providing a reproduction script.** See these examples:
-
-* [Git environment variables causing install to fail.](https://gist.github.com/xaviershay/6207550)
-* [Multiple gems in a repository cannot be updated independently.](https://gist.github.com/xaviershay/6295889)
-
-A half working script with comments for the parts you were unable to automate is still appreciated.
-
-If you are unable to do that, please include the following information in your report:
-
- - What you're trying to accomplish
- - The command you ran
- - What you expected to happen
- - What actually happened
- - The exception backtrace(s), if any
- - Everything output by running `bundle env`
-
-If your version of Bundler does not have the `bundle env` command, then please include:
-
- - Your `Gemfile`
- - Your `Gemfile.lock`
- - Your Bundler configuration settings (run `bundle config`)
- - What version of bundler you are using (run `bundle -v`)
- - What version of Ruby you are using (run `ruby -v`)
- - What version of RubyGems you are using (run `gem -v`)
- - Whether you are using RVM, and if so what version (run `rvm -v`)
- - Whether you have the `rubygems-bundler` gem, which can break gem executables (run `gem list rubygems-bundler`)
- - Whether you have the `open_gem` gem, which can cause rake activation conflicts (run `gem list open_gem`)
-
-If you have either `rubygems-bundler` or `open_gem` installed, please try removing them and then following the troubleshooting steps above before opening a new ticket.
-
-[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/rubygems/bundler/issues) and [create a ticket](https://github.com/rubygems/bundler/issues/new) describing your problem and linking to your gist.
-
-Thanks for reporting issues and helping make Bundler better!
diff --git a/bundler/doc/contributing/README.md b/bundler/doc/contributing/README.md
index 9e6a6fc48..1ca803e5a 100644
--- a/bundler/doc/contributing/README.md
+++ b/bundler/doc/contributing/README.md
@@ -4,11 +4,10 @@ Thank you for your interest in making Bundler better! We welcome contributions f
 
 Before submitting a contribution, read through the following guidelines:
 
-* [Bundler Code of Conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md) (By participating in Bundler, you agree to abide by the terms laid out in the CoC.)
-* [Issue Reporting Guidelines](https://github.com/rubygems/bundler/blob/master/doc/contributing/ISSUES.md)
-* [Pull Request Guidelines](https://github.com/rubygems/bundler/blob/master/doc/development/PULL_REQUESTS.md)
+* [Bundler Code of Conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) (By participating in Bundler, you agree to abide by the terms laid out in the CoC.)
+* [Pull Request Guidelines](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md)
 
-And be sure to [set up your development environment](https://github.com/rubygems/bundler/blob/master/doc/development/SETUP.md).
+And be sure to [set up your development environment](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/SETUP.md).
 
 ## Feature Requests
 
@@ -18,11 +17,11 @@ To request substantial changes to Bundler and/or Bundler documentation, please r
 
 Here are the different ways you can start contributing to the Bundler project:
 
-* [First contribution suggestions](https://github.com/rubygems/bundler/blob/master/doc/contributing/HOW_YOU_CAN_HELP.md)
-* [Adding new features](https://github.com/rubygems/bundler/blob/master/doc/development/NEW_FEATURES.md)
-* [Triaging bugs](https://github.com/rubygems/bundler/blob/master/doc/contributing/BUG_TRIAGE.md)
-* [Writing documentation](https://github.com/rubygems/bundler/blob/master/doc/documentation/WRITING.md)
-* [Community engagement](https://github.com/rubygems/bundler/blob/master/doc/contributing/COMMUNITY.md)
+* [First contribution suggestions](/bundler/doc/contributing/HOW_YOU_CAN_HELP.md)
+* [Adding new features](/bundler/doc/development/NEW_FEATURES.md)
+* [Triaging bugs](/bundler/doc/contributing/BUG_TRIAGE.md)
+* [Writing documentation](/bundler/doc/documentation/WRITING.md)
+* [Community engagement](/bundler/doc/contributing/COMMUNITY.md)
 
 ## Supporting Bundler
 
diff --git a/bundler/doc/development/NEW_FEATURES.md b/bundler/doc/development/NEW_FEATURES.md
index 0e9864def..aac439138 100644
--- a/bundler/doc/development/NEW_FEATURES.md
+++ b/bundler/doc/development/NEW_FEATURES.md
@@ -2,7 +2,7 @@
 
 If you would like to add a new feature to Bundler, please follow these steps:
 
-  1. [Create an issue](https://github.com/rubygems/bundler/issues/new) with the [`feature-request` label](https://github.com/rubygems/bundler/labels/type:%20feature-request) to discuss your feature.
+  1. [Create an issue](https://github.com/rubygems/rubygems/issues/new) with the [`feature-request` label](https://github.com/rubygems/rubygems/labels/type:%20feature-request) to discuss your feature.
   2. Base your commits on the master branch, since we follow [SemVer](https://semver.org) and don't add new features to old releases.
   3. Commit the code and at least one test covering your changes to a feature branch in your fork.
   4. Send us a [pull request](PULL_REQUESTS.md) from your feature branch.
diff --git a/bundler/doc/development/PULL_REQUESTS.md b/bundler/doc/development/PULL_REQUESTS.md
index 09428f057..94edda896 100644
--- a/bundler/doc/development/PULL_REQUESTS.md
+++ b/bundler/doc/development/PULL_REQUESTS.md
@@ -16,7 +16,7 @@ Make sure the code formatting and styling adheres to the guidelines. We use Rubo
 
 Prior to submitting your PR, please run the test suite:
 
-      $ bin/rspec
+      $ bin/parallel_rspec
 
 If you are unable to run the entire test suite, please run the unit test suite and at least the integration specs related to the command or domain of Bundler that your code changes relate to.
 
diff --git a/bundler/doc/development/README.md b/bundler/doc/development/README.md
index 016946347..a1850831f 100644
--- a/bundler/doc/development/README.md
+++ b/bundler/doc/development/README.md
@@ -13,7 +13,3 @@ An overview of our preferred PR process, including how to run the test suite and
 ## [Adding new features](NEW_FEATURES.md)
 
 Guidelines for proposing and writing new features for Bundler.
-
-## [Releasing Bundler](RELEASING.md)
-
-A broad-strokes overview of the release process adhered to by the Bundler core team.
diff --git a/bundler/doc/development/SETUP.md b/bundler/doc/development/SETUP.md
index 4b91a8383..5e693803d 100644
--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -1,36 +1,36 @@
-# Development setup
+# Bundler Development setup
 
-Bundler doesn't use a Gemfile to list development dependencies, because when we tried it we couldn't tell if we were awake or it was just another level of dreams. To work on Bundler, you'll probably want to do a couple of things:
+To work on Bundler, you'll probably want to do a couple of things:
 
-1. [Fork the Bundler repo](https://github.com/rubygems/bundler), and clone the fork onto your machine. ([Follow this tutorial](https://help.github.com/articles/fork-a-repo/) for instructions on forking a repo.)
+* [Fork the Rubygems repo](https://github.com/rubygems/rubygems), and clone the fork onto your machine. ([Follow this tutorial](https://help.github.com/articles/fork-a-repo/) for instructions on forking a repo.)
 
-2. Install `groff-base` and `graphviz` packages using your package manager:
+* Install `graphviz` package using your package manager:
 
-        $ sudo apt-get install graphviz groff-base -y
+        $ sudo apt-get install graphviz -y
 
     And for OS X (with brew installed):
 
-        $ brew install graphviz groff
+        $ brew install graphviz
 
-3. You may also have to install the `bsdmainutils` package on linux if your distribution does not include the `col` command.
+* From the rubygems root directory change into the bundler directory:
 
-        $ sudo apt-get install bsdmainutils -y
+        $ cd bundler
 
-4. Install Bundler's development dependencies:
+* Install Bundler's development dependencies:
 
-        $ bin/rake spec:deps
+        $ rake spec:deps
 
-5. Run the test suite, to make sure things are working:
+* Run the test suite, to make sure things are working:
 
         $ bin/rake spec
 
-6. Optionally, you can run the test suite in parallel:
+* Optionally, you can run the test suite in parallel:
 
-        $ bin/parallel_rspec spec
+        $ bin/parallel_rspec
 
-7. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
+* Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 
-        $ alias dbundle='/path/to/bundler/repo/bin/bundle'
+        $ alias dbundle='ruby /path/to/bundler/repo/spec/support/bundle.rb'
 
 ## Debugging with `pry`
 
diff --git a/bundler/doc/documentation/README.md b/bundler/doc/documentation/README.md
index 48d697974..92cf8c6e1 100644
--- a/bundler/doc/documentation/README.md
+++ b/bundler/doc/documentation/README.md
@@ -14,7 +14,7 @@ Not sure where to write documentation? In general, follow these guidelines:
 * For an explanation of a specific Bundler command (ex: `bundle clean`): make changes to the man pages
 * For longer explanations or usage guides (ex: "Using Bundler with Rails"): create new documentation within the [bundler-site](https://github.com/rubygems/bundler-site) repository
 
-If you are unsure where to begin, ping [@feministy](https://github.com/feministy) or [@indirect](https://github.com/indirect) in the Bundler Slack ([get an invite here](../contributing/GETTING_HELP.md)).
+If you are unsure where to begin, ping [@feministy](https://github.com/feministy) or [@indirect](https://github.com/indirect) in [the Bundler Slack](https://slack.bundler.io).
 
 ## [Writing docs for man pages](WRITING.md)
 
diff --git a/bundler/doc/documentation/WRITING.md b/bundler/doc/documentation/WRITING.md
index e529c0af7..8680d8935 100644
--- a/bundler/doc/documentation/WRITING.md
+++ b/bundler/doc/documentation/WRITING.md
@@ -1,5 +1,7 @@
 # Writing docs for man pages
 
+*Any commands or file paths in this document assume that you are inside [the bundler/ directory of the rubygems/rubygems repository](https://github.com/rubygems/rubygems/tree/master/bundler).*
+
 A primary source of help for Bundler users are the man pages: the output printed when you run `bundle help` (or `bundler help`). These pages can be a little tricky to format and preview, but are pretty straightforward once you get the hang of it.
 
 _Note: `bundler` and `bundle` may be used interchangeably in the CLI. This guide uses `bundle` because it's cuter._
@@ -18,9 +20,9 @@ Don't see a man page for a command? Make a new page and send us a PR! We also we
 
 ## Creating a new man page
 
-To create a new man page, simply create a new `.ronn` file in the `man/` directory.
+To create a new man page, simply create a new `.ronn` file in the `lib/bundler/man/` directory.
 
-For example: to create a man page for the command `bundle cookies` (not a real command, sadly), I would create a file `man/bundle-cookies.ronn` and add my documentation there.
+For example: to create a man page for the command `bundle cookies` (not a real command, sadly), I would create a file `lib/bundler/man/bundle-cookies.1.ronn` and add my documentation there.
 
 ## Formatting
 
@@ -42,7 +44,7 @@ $ rake man:build
 $ man man/bundle-cookies.1
 ```
 
-If you make more changes to `bundle-cookies.ronn`, you'll need to run the `rake man:build` again before previewing.
+If you make more changes to `bundle-cookies.1.ronn`, you'll need to run the `rake man:build` again before previewing.
 
 ## Testing
 
@@ -55,9 +57,9 @@ $ bin/rspec ./spec/quality_spec.rb
 
 # Writing docs for [the Bundler documentation site](https://bundler.io)
 
-If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/bundler` repository. They are the same in each case.
+If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/rubygems` repository. They are the same in each case.
 
-Note: Editing `.ronn` files from the `rubygems/bundler` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/bundler` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
+Note: Editing `.ronn` files from the `rubygems/rubygems` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/rubygems` repository's `.ronn` files from the `rake man/build` command.
 
 Additionally, if you'd like to add a guide or tutorial: in the `rubygems/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
 ```
diff --git a/bundler/doc/playbooks/MERGING_A_PR.md b/bundler/doc/playbooks/MERGING_A_PR.md
new file mode 100644
index 000000000..4ba6f85dd
--- /dev/null
+++ b/bundler/doc/playbooks/MERGING_A_PR.md
@@ -0,0 +1,39 @@
+# Merging a PR
+
+Bundler requires all CI status checks to pass before a PR can me merged. So make
+sure that's the case before merging.
+
+Also, bundler manages the changelog automatically using information from merged
+PRs. So, if a PR has user visible changes that should be included in a future
+release, make sure the following information is accurate:
+
+* The PR has a good descriptive title. That will be the wording for the
+  corresponding changelog entry.
+
+* The PR has an accurate label. If a PR is to be included in the changelog since
+  it has user visible changes, the label must be one of the following:
+
+  * "bundler: security fix"
+  * "bundler: breaking change"
+  * "bundler: major enhancement"
+  * "bundler: deprecation"
+  * "bundler: feature"
+  * "bundler: performance"
+  * "bundler: documentation"
+  * "bundler: minor enhancement"
+  * "bundler: bug fix"
+
+  This label will indicate the section in the changelog that the PR will take,
+  and it will also be automatically used by our release tasks for backporting.
+  The labels that should be backported only to patch level releases, and to
+  either patch level or minor releases can be configured in the `.changelog.yml`
+  file.
+
+  If for some reason you need a PR to be backported to a stable branch, but it
+  doesn't have any user visible changes, apply the "bundler: backport" label to
+  it so that our release scripts know about that.
+
+Finally, don't forget to review the changes in detail. Make sure you try them
+locally if they are not trivial and make sure you request changes and ask as
+many questions as needed until you are convinced that including the changes into
+bundler is a strict improvement and will not make things regress in any way.
diff --git a/bundler/doc/playbooks/RELEASING.md b/bundler/doc/playbooks/RELEASING.md
index c618488ef..c7f16dddf 100644
--- a/bundler/doc/playbooks/RELEASING.md
+++ b/bundler/doc/playbooks/RELEASING.md
@@ -3,11 +3,11 @@
 Bundler uses [Semantic Versioning](https://semver.org/).
 
 _Note: In the documentation listed below, the *current* minor version number is
-1.11 and the *next* minor version number is 1.12_
+2.1 and the *next* minor version number is 2.2_
 
 Regardless of the version, *all releases* must update the `CHANGELOG.md` and `lib/bundler/version.rb`
-files. The changelog for the first stable minor release (`1.12.0`) is a sum of all
-the preceding pre-release versions (`1.12.pre.1`, `1.12.pre.2`, etc) for that
+files. The changelog for the first stable minor release (`2.2.0`) is a sum of all
+the preceding pre-release versions (`2.2.pre.1`, `2.2.pre.2`, etc) for that
 minor version. The changelog for the first stable minor release is left blank
 unless there are fixes included since the last pre/rc release.
 
@@ -15,8 +15,8 @@ unless there are fixes included since the last pre/rc release.
 
 In general, `master` will accept PRs for:
 
-* feature merges for the next minor version (1.12)
-* regression fix merges for a patch release on the current minor version (1.11)
+* feature merges for the next minor version (2.2)
+* regression fix merges for a patch release on the current minor version (2.1)
 * feature-flagged development for the next major version (2.0)
 
 ### Breaking releases
@@ -29,11 +29,54 @@ behaviors that will change.
 We try very hard to only release breaking changes when incrementing the _major_
 version of Bundler.
 
-### Cherry picking
+### Patch && minor releases
 
-Patch releases are made by cherry-picking bug fixes from `master`.
+While pushing a gem version to RubyGems.org is as simple as `rake release`,
+releasing a new version of Bundler includes a lot of communication: team
+consensus, git branching, documentation site updates, and a blog post.
+
+Patch and minor releases are made by cherry-picking pill requests from `master`.
+
+### Branching
+
+Bundler releases are synchronized with rubygems releases at the moment. That
+means that releases for both share the same stable branch, and they should
+generally happen together.
 
-When we cherry-pick, we cherry-pick the merge commits using the following command:
+Minor releases of the next version start with a new release branch from the
+current state of master: `3.2`, and are immediately followed by a prerelease
+(might be a `.pre.1` version or a `.rc.1` version depending on the readiness of
+the stable branch) or even directly by the final stable release.
+
+The current conventional naming for stable branches is `x+1.y`, where `x.y` is
+the version of `bundler` that will be released. This is because `rubygems-x+1.y`
+will be released at the same time.
+
+For example, `rubygems-3.2.0` and `bundler-2.2.0` will be both released from the
+`3.2` stable branch.
+
+Once a stable branch has been cut from `master`, changes for that minor release
+series (bundler 2.2) will only be made _intentionally_, via patch releases.
+That is to say, changes to `master` by default _won't_ make their way into any
+`2.2` version, and development on `master` will be targeting the next minor
+or major release.
+
+There is a `rake prepare_stable_branch[<target_rubugems_version>]` rake task
+that helps with creating a release. It takes a single argument, the _exact
+rubygems release_ being made (e.g.  `3.2.3` when releasing bundler `2.2.3`).
+This task checks out the appropriate stable branch (`3.2`), grabs all merged but
+unreleased PRs from both bundler & rubygems from GitHub that are compatible with
+the target release level, and then cherry-picks those changes (and only those
+changes) to a new branch based off the stable branch. Then bumps the version in
+all version files, synchronizes both changelogs to include all backported
+changes and commits that change on top of the cherry-picks.
+
+Note that this task requires all user facing pull requests to be tagged with
+specific labels. See [Merging a PR](/bundler/doc/playbooks/MERGING_A_PR.md) for
+details.
+
+Also note that when this task cherry-picks, it cherry-picks the merge commits
+using the following command:
 
 ```bash
 $ git cherry-pick -m 1 MERGE_COMMIT_SHAS
@@ -48,60 +91,41 @@ using:
 $ git cherry-pick -m 1 dd6aef9
 ```
 
-The `rake release:prepare_patch` command will automatically handle
-cherry-picking, and is further detailed below.
-
-## Changelog
-
-Bundler maintains a list of changes present in each version in the `CHANGELOG.md` file.
-Entries should not be added in pull requests, but are rather written by the Bundler
-maintainers before the release.
-
-To fill in the changelog, maintainers can go through the relevant PRs using the
-`rake release:open_unreleased_prs` and manually add a changelog entry for each
-PR that it's about to be released.
-
-If you're releasing a patch level version, you can use `rake
-release:open_unreleased_prs` to instead label each relevant PR with the proper
-milestone of the version to be release. Then the `rake release:patch` task will
-go _only_ through those PRs, and prompt you to add a changelog entry for each of
-them.
-
-## Releases
-
-### Minor releases
-
-While pushing a gem version to RubyGems.org is as simple as `rake release`,
-releasing a new version of Bundler includes a lot of communication: team consensus,
-git branching, changelog writing, documentation site updates, and a blog post.
-
-Dizzy yet? Us too.
+After running the task, you'll have a release branch ready to be merged into the
+stable branch. You'll want to open a PR from this branch into the stable branch
+and provided CI is green, you can go ahead, merge the PR and run `bin/rake
+release` from `bundler/` directory in the updated stable branch.
 
 Here's the checklist for releasing new minor versions:
 
 * [ ] Check with the core team to ensure that there is consensus around shipping a
   feature release. As a general rule, this should always be okay, since features
   should _never break backwards compatibility_
-* [ ] Create a new stable branch from master (see **Branching** below)
-* [ ] Update `version.rb` to a prerelease number, e.g. `1.12.pre.1`
-* [ ] Update `CHANGELOG.md` to include all of the features, bugfixes, etc for that
-  version.
-* [ ] Run `rake release`, tweet, blog, let people know about the prerelease!
+* [ ] Run `rake prepare_stable_branch[<target_rubygems_pre_version>]` and create
+  a PR to the stable branch with the generated changes.
+* [ ] Get the PR reviewed, make sure CI is green, and merge it.
+* [ ] Pull the updated stable branch, wait for CI to complete on it and get excited.
+* [ ] Run `bin/rake release` from the `bundler/` directory updated stable
+  branch, tweet, blog, let people know about the prerelease!
 * [ ] Wait a **minimum of 7 days**
-* [ ] If significant problems are found, increment the prerelease (i.e. 1.12.pre.2)
+* [ ] If significant problems are found, increment the prerelease (i.e. 2.2.pre.2)
   and repeat, but treating `.pre.2` as a _patch release_. In general, once a stable
   branch has been cut from master, it should _not_ have master merged back into it.
 
 Wait! You're not done yet! After your prelease looks good:
 
-* [ ] Update `version.rb` to a final version (i.e. 1.12.0)
+* [ ] Run `rake prepare_stable_branch[<target_rubygems_version>]` and create a
+  PR to the stable branch.
+* [ ] Get the PR reviewed, make sure CI is green, and merge it.
 * [ ] In the [rubygems/bundler-site](https://github.com/rubygems/bundler-site) repo,
-  copy the previous version's docs to create a new version (e.g. `cp -r v1.11 v1.12`)
+  copy the previous version's docs to create a new version (e.g. `cp -r v2.1 v2.2`)
 * [ ] Update the new docs as needed, paying special attention to the "What's new"
   page for this version
 * [ ] Write a blog post announcing the new version, highlighting new features and
   notable bugfixes
-* [ ] Run `rake release` in the bundler repo, tweet, link to the blog post, etc.
+* [ ] Pull the updated stable branch, wait for CI to complete on it and get excited.
+* [ ] Run `bin/rake release` in the `bundler/` directory of the updated stable
+  branch, tweet, link to the blog post, etc.
 
 At this point, you're a release manager! Pour yourself several tasty drinks and
 think about taking a vacation in the tropics.
@@ -110,42 +134,6 @@ Beware, the first couple of days after the first non-prerelease version in a min
 series can often yield a lot of bug reports. This is normal, and doesn't mean you've done
 _anything_ wrong as the release manager.
 
-#### Branching
-
-Minor releases of the next version start with a new release branch from the
-current state of master: `1-12-stable`, and are immediately followed by a `.pre.1` release.
-
-Once that `-stable` branch has been cut from `master`, changes for that minor
-release series (1.12) will only be made _intentionally_, via patch releases.
-That is to say, changes to `master` by default _won't_ make their way into any
-`1.12` version, and development on `master` will be targeting the next minor
-or major release.
-
-### Patch releases (bug fixes!)
-
-Releasing new bugfix versions is really straightforward. Increment the tiny version
-number in `lib/bundler/version.rb`, and in `CHANGELOG.md` add one bullet point
-per bug fixed. Then run `rake release` from the `-stable` branch,
-and pour yourself a tasty drink!
-
-PRs containing regression fixes for a patch release of the current minor version
-are merged to master. These commits need to be cherry-picked from master onto
-the minor branch (`1-12-stable`).
-
-There is a `rake release:prepare_patch` rake task that helps with creating a patch
-release. It takes a single argument, the _exact_ patch release being made (e.g.
-`1.12.3`), but if not given it will bump the tiny version number by one. This
-task checks out the appropriate stable branch (`1-12-stable`), grabs the
-`1.12.3` milestone from GitHub, ensures all PRs are closed, and then
-cherry-picks those changes (and only those changes) to a new branch based off
-the stable branch. Then bumps the version in the version file and commits that
-change on top of the cherry-picks.
-
-Now you have a release branch ready to be merged into the stable branch. You'll
-want to open a PR from this branch into the stable branch and provided CI is
-green, you can go ahead, merge the PR and run `rake release` from the updated
-stable branch.
-
 ## Beta testing
 
 Early releases require heavy testing, especially across various system setups.
diff --git a/bundler/doc/playbooks/TEAM_CHANGES.md b/bundler/doc/playbooks/TEAM_CHANGES.md
index fe3dfecb5..865719d53 100644
--- a/bundler/doc/playbooks/TEAM_CHANGES.md
+++ b/bundler/doc/playbooks/TEAM_CHANGES.md
@@ -15,7 +15,7 @@ Interested in adding someone to the team? Here's the process.
     - Add them to the [maintainers team][org_team] on GitHub
     - Add them to the [Team page][team] on bundler.io, in the [maintainers list][maintainers]
     - Add them to the [list of team members][list] in `contributors.rake`
-    - Add them to the authors list in `bundler.gemspec`
+    - Add them to the authors list in `bundler.gemspec` && `rubygems-update.gemspec`
     - Add them to the owners list on RubyGems.org by running
       ```
       $ gem owner -a EMAIL bundler
@@ -24,7 +24,7 @@ Interested in adding someone to the team? Here's the process.
 
 ## Removing a team member
 
-When the conditions in [POLICIES](https://github.com/rubygems/bundler/blob/master/doc/POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
+When the conditions in [POLICIES](https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
 
 - Remove them from the owners list on RubyGems.org by running
   ```
@@ -35,8 +35,8 @@ When the conditions in [POLICIES](https://github.com/rubygems/bundler/blob/maste
 - Remove them from the [maintainers team][org_team] on GitHub
 - Remove them from the maintainers Slack channel
 
-[policies]: https://github.com/rubygems/bundler/blob/master/doc/POLICIES.md#bundler-policies
-[org_team]: https://github.com/orgs/bundler/teams/maintainers/members
+[policies]: https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#bundler-policies
+[org_team]: https://github.com/orgs/rubygems/teams/maintainers/members
 [team]: https://bundler.io/contributors.html
-[maintainers]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/source/contributors.html.haml#L25
-[list]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/lib/tasks/contributors.rake#L8
+[maintainers]: https://github.com/rubygems/bundler-site/blob/f00eb65da0697c2cb0e7b4d6e5ba47ecc1538eb2/source/contributors.html.haml#L25
+[list]: https://github.com/rubygems/bundler-site/blob/f00eb65da0697c2cb0e7b4d6e5ba47ecc1538eb2/lib/tasks/contributors.rake#L8
````

</details>

### What is your fix for the problem, implemented in this PR?

Updates the settings of the upstream Git repo and refactors some code relevant to the task.

As `/source/conduct.html.md` has been tracked in Git, it is updated in this PR while other files in `/source/doc/*` have not.

This would bring us all changes in /bundler/doc/ and /CODE_OF_CONDUCT.md in rubygems/rubygems after 2020-03-15.

### Why did you choose this fix out of the possible options?

We cannot leave them as-is.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
