### PR TITLE
Use https for arko.net

### DIFF
--- a/source/blog/2013-12-07-the-rumors-of-bundlers-death-have-been-greatly-exaggerated.html.markdown
+++ b/source/blog/2013-12-07-the-rumors-of-bundlers-death-have-been-greatly-exaggerated.html.markdown
@@ -3,7 +3,7 @@ title: The rumors of Bundler's death have been greatly exaggerated
 date: 2013/12/07
 draft: false
 author: André Arko
-author_url: http://arko.net
+author_url: https://arko.net
 category: annoucement
 ---
 

--- a/source/blog/2014-07-16-bundler-api-outages.html.markdown
+++ b/source/blog/2014-07-16-bundler-api-outages.html.markdown
@@ -2,7 +2,7 @@
 title: Bundler API outages on July 15 & 16, 2014
 date: 2014-07-16 23:29 UTC
 author: André Arko
-author_url: http://arko.net
+author_url: https://arko.net
 category: postmortem
 ---
 

--- a/source/blog/2014-08-14-bundler-may-install-gems-from-a-different-source-than-expected-cve-2013-0334.html.markdown
+++ b/source/blog/2014-08-14-bundler-may-install-gems-from-a-different-source-than-expected-cve-2013-0334.html.markdown
@@ -2,7 +2,7 @@
 title: Bundler may install gems from a different source than expected (CVE-2013-0334)
 date: 2014-08-14 01:22 UTC
 author: André Arko
-author_url: http://arko.net
+author_url: https://arko.net
 category: security, release
 ---
 

--- a/source/blog/2014-08-15-gem-not-found-error-on-1-7-0.html.markdown
+++ b/source/blog/2014-08-15-gem-not-found-error-on-1-7-0.html.markdown
@@ -2,7 +2,7 @@
 title: Gem not found error on 1.7.0
 date: 2014-08-15 17:02 UTC
 author: André Arko
-author_url: "http://arko.net"
+author_url: "https://arko.net"
 category: announcement
 ---
 After the release of Bundler 1.7.0 yesterday, we discovered a bug that can cause Bundler to report that a gem was not found, even though that gem is available from one of the relevant sources. We're understand the problem, and we're working on a fix as fast as we can. In the meantime, it's possible to work completely around the problem by adding the `--full-index` option when you run `bundle install`. I fully recognize that it sucks to have a regression in a security update, and I'm sorry that this happened. I can't guarantee something like this well never happen again, but we're adding tests to prevent this particular bug from recurring.

--- a/source/blog/2015-03-19-announcing-ruby-together.html.markdown
+++ b/source/blog/2015-03-19-announcing-ruby-together.html.markdown
@@ -1,7 +1,7 @@
 ---
 title: Announcing Ruby Together
 date: 2015-03-19 02:56 UTC
-author_url: "http://arko.net"
+author_url: "https://arko.net"
 category: announcement
 ---
 

--- a/source/blog/2015-06-24-version-1-10-released.html.markdown
+++ b/source/blog/2015-06-24-version-1-10-released.html.markdown
@@ -3,7 +3,7 @@ title: Version 1.10 released
 date: 2015-06-24 05:36 UTC
 tags:
 author: André Arko
-author_url: http://arko.net
+author_url: https://arko.net
 category: release
 ---
 

--- a/source/blog/2016-04-28-the-new-index-format-fastly-and-bundler-1-12.html.md
+++ b/source/blog/2016-04-28-the-new-index-format-fastly-and-bundler-1-12.html.md
@@ -3,7 +3,7 @@ title: The new index format, Fastly, and Bundler 1.12
 date: 2016-04-28 23:00 UTC
 tags:
 author: André Arko
-author_url: http://arko.net
+author_url: https://arko.net
 category: release
 ---
 

--- a/source/blog/2016-09-08-bundler-1-13.html.md
+++ b/source/blog/2016-09-08-bundler-1-13.html.md
@@ -3,7 +3,7 @@ title: "Bundler 1.13: The one with steady improvements"
 date: 2016-09-08 23:00 UTC
 tags:
 author: André Arko
-author_url: http://arko.net
+author_url: https://arko.net
 category: release
 ---
 


### PR DESCRIPTION
As `arko.net` supports for HTTPS, these URLs can be updated.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)