### PR TITLE
Heroku domain is now on herokuapp.com

### DIFF
--- a/source/blog/2013-10-12-goodbye-bundler-14-hello-bundler-15.html.markdown
+++ b/source/blog/2013-10-12-goodbye-bundler-14-hello-bundler-15.html.markdown
@@ -3,7 +3,7 @@ title: Goodbye Bundler 1.4, Hello Bundler 1.5
 date: 2013/10/12
 draft: false
 author: Terence Lee
-author_url: https://hone.heroku.com
+author_url: https://hone.herokuapp.com
 category: release
 ---
 


### PR DESCRIPTION
Heroku's subdomain has been under `herokuapp.com` instead of `heroku.com` for so many years.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)