### PR TITLE
Enable RuboCop entirely in HAML-Lint

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -31,10 +31,7 @@ linters:
       - "source/guides/bundler_plugins.html.haml"
 
   RuboCop:
-    exclude:
-      - "source/contributors.html.haml"
-      - "source/layouts/_favicon.haml"
-      - "source/layouts/blog_layout.haml"
+    enabled: true
 
   SpaceBeforeScript:
     exclude:

--- a/source/contributors.html.haml
+++ b/source/contributors.html.haml
@@ -16,8 +16,8 @@ title: Contributors
 
 %svg.clip-svg{style: 'position: absolute;'}
   %defs
-    %clipPath#polygon{:clipPathUnits => 'objectBoundingBox'}
-      %polygon{:points => '0.25 0.06, 0.75 0.06, 1 0.5, 0.75 0.94, 0.25 0.94, 0 0.5'}
+    %clipPath#polygon{clipPathUnits: 'objectBoundingBox'}
+      %polygon{points: '0.25 0.06, 0.75 0.06, 1 0.5, 0.75 0.94, 0.25 0.94, 0 0.5'}
 
 .container
   .row

--- a/source/layouts/_favicon.haml
+++ b/source/layouts/_favicon.haml
@@ -1,8 +1,8 @@
-%link{:href => "/images/apple-touch-icon.png", :rel => "apple-touch-icon", :sizes => "180x180"}/
-%link{:href => "/images/favicon-32x32.png", :rel => "icon", :sizes => "32x32", :type => "image/png"}/
-%link{:href => "/images/favicon-16x16.png", :rel => "icon", :sizes => "16x16", :type => "image/png"}/
-%link{:href => "/manifest.json", :rel => "manifest"}/
-%link{:color => "#50bced", :href => "/images/safari-pinned-tab.svg", :rel => "mask-icon"}/
-%meta{:content => "bundler.io", :name => "apple-mobile-web-app-title"}/
-%meta{:content => "bundler.io", :name => "application-name"}/
-%meta{:content => "#ffffff", :name => "theme-color"}/
+%link{href: "/images/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180"}/
+%link{href: "/images/favicon-32x32.png", rel: "icon", sizes: "32x32", type: "image/png"}/
+%link{href: "/images/favicon-16x16.png", rel: "icon", sizes: "16x16", type: "image/png"}/
+%link{href: "/manifest.json", rel: "manifest"}/
+%link{color: "#50bced", href: "/images/safari-pinned-tab.svg", rel: "mask-icon"}/
+%meta{content: "bundler.io", name: "apple-mobile-web-app-title"}/
+%meta{content: "bundler.io", name: "application-name"}/
+%meta{content: "#ffffff", name: "theme-color"}/

--- a/source/layouts/blog_layout.haml
+++ b/source/layouts/blog_layout.haml
@@ -8,7 +8,7 @@
             = link_to current_article.title, current_article.url
           .subtitle
             by
-            = link_to current_article.data.author, current_article.data.author_url, :target => '_blank'
+            = link_to current_article.data.author, current_article.data.author_url, target: '_blank'
             on
             %time
               = current_article.date.strftime('%b %e %Y')


### PR DESCRIPTION
Prior to #775, remove `exclude` from the `RuboCop` rule in HAML-Lint.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>