### PR TITLE
Remove .btn-margin-top CSS

### DIFF
--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -88,10 +88,6 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
   font-size: 19px;
 }
 
-.btn-margin-top {
-  margin-top: 35px;
-}
-
 .btn {
   margin-top: 10px;
   margin-bottom: 35px;

--- a/source/404.html.haml
+++ b/source/404.html.haml
@@ -1,5 +1,5 @@
 .container
-  .col-md-12.text-center.btn-margin-top
+  .col-md-12.text-center.my-5
     %h1
       %b Page not found
 

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -32,7 +32,7 @@
     %h2#getting-started
       %b= t('home.getting_started')
 
-    .large-font.btn-margin-top
+    .large-font.mt-4
       .bullet
         .description
           %p= t('home.getting_started_description')


### PR DESCRIPTION
Remove .btn-margin-top CSS introduced in https://github.com/rubygems/bundler-site/pull/218/commits/ce8a254ac774b834310f9afd625b3b977fbc7e2b by replacing it with Bootstrap 5 framework. 

Fixes up #218

### `/` (top)
![bundler-site-tnir-remov-6azcny herokuapp com_](https://user-images.githubusercontent.com/10229505/181444203-260cf936-1458-4f56-a787-01ccf44e9443.png)

### `/404.html` (404)
![bundler-site-tnir-remov-6azcny herokuapp com_404 html](https://user-images.githubusercontent.com/10229505/181444195-e9bdea12-e7e2-44ef-8422-59abdeb823e9.png)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)