### PR TITLE
Use the same repository but the different branch for GitHub Pages for production

### DIFF
--- a/lib/tasks/ci/deploy.rake
+++ b/lib/tasks/ci/deploy.rake
@@ -26,6 +26,9 @@ namespace :ci do
     commit = `git rev-parse HEAD`.chomp
 
     Dir.chdir "vendor/ssh_bundler.github.io" do
+      BRANCH_FOR_PAGES = "gh-pages".freeze
+      sh "git checkout #{BRANCH_FOR_PAGES}"
+
       rm_rf FileList["*"]
       cp_r FileList["../../build/*"], "./"
       File.write("CNAME", "bundler.io")
@@ -36,7 +39,7 @@ namespace :ci do
       sh "git config user.email '#{commit_author_email}'"
 
       sh "git commit -m 'rubygems/bundler-site@#{commit}'"
-      sh "git push origin master"
+      sh "git push origin #{BRANCH_FOR_PAGES}"
     end
   end
 end

--- a/lib/tasks/ci/ssh_repo.rake
+++ b/lib/tasks/ci/ssh_repo.rake
@@ -1,13 +1,15 @@
 directory "vendor/ssh_bundler.github.io" => ["vendor"] do
-  system "git clone git@github.com:bundler/bundler.github.io vendor/ssh_bundler.github.io"
+  system "git clone https://github.com/rubygems/bundler-site.git vendor/ssh_bundler.github.io"
 end
 
 namespace :ci do
   task update_ssh_site: "vendor/ssh_bundler.github.io" do
     Dir.chdir "vendor/ssh_bundler.github.io" do
-      sh "git checkout master"
+      BRANCH_FOR_PAGES = "gh-pages".freeze
+
+      sh "git checkout #{BRANCH_FOR_PAGES}"
       sh "git reset --hard HEAD"
-      sh "git pull origin master"
+      sh "git pull origin #{BRANCH_FOR_PAGES}"
     end
   end
 end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,8 +1,11 @@
-desc "Release the current commit to bundler/bundler.github.io"
+desc "Release the current commit to gh-pages on rubygems/bundler-site"
 task release: [:build, :update_site] do
   commit = `git rev-parse HEAD`.chomp
+  BRANCH_FOR_PAGES = "gh-pages".freeze
 
   Dir.chdir "vendor/bundler.github.io" do
+    sh "git checkout #{BRANCH_FOR_PAGES}"
+
     rm_rf FileList["*"]
     cp_r FileList["../../build/*"], "./"
     File.write("CNAME", "bundler.io")
@@ -18,11 +21,11 @@ account, you will need to use a github access token instead of your
 account password.
 ====================================================================
       TWO_FACTOR_WARNING
-      sh "git push origin master"
+      sh "git push origin #{BRANCH_FOR_PAGES}"
     end
   end
 
   Bundler.with_clean_env do
-    sh "git push origin master"
+    sh "git push origin #{BRANCH_FOR_PAGES}"
   end
 end

--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -69,13 +69,15 @@ task repo_pages: :update_vendor do
 end
 
 directory "vendor/bundler.github.io" => ["vendor"] do
-  system "git clone https://github.com/bundler/bundler.github.io vendor/bundler.github.io"
+  system "git clone https://github.com/rubygems/bundler-site.git vendor/bundler.github.io"
 end
 
 task update_site: "vendor/bundler.github.io" do
   Dir.chdir "vendor/bundler.github.io" do
-    sh "git checkout master"
+    BRANCH_FOR_PAGES = "gh-pages".freeze
+
+    sh "git checkout #{BRANCH_FOR_PAGES}"
     sh "git reset --hard HEAD"
-    sh "git pull origin master"
+    sh "git pull origin #{BRANCH_FOR_PAGES}"
   end
 end


### PR DESCRIPTION
Closes #591

Changes the publishing source for GitHub Pages for `https://bundler.io`.

- before: https://github.com/rubygems/bundler.github.io/tree/master
- after: https://github.com/rubygems/bundler-site/tree/gh-pages

## Notes
- `ci:update_ssh_site` Rake task does now use HTTPS over SSH per [GitHub recommendation](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories) and thanks to pre-defined token in GitHub Actions. Unify it with `update_site` Rake task in another PR.
- `configure_ssh_deploy_key` remains. Remove it in another PR.
- Permissions in GitHub Actions are not changed. Improve it in another PR.
- New Custom GitHub Actions Workflows (beta) for GitHub Pages are not included. See https://github.com/middleman/middleman/issues/2561
   - or https://github.com/rubygems/bundler-site/issues/790

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)