### PR TITLE
Use SSH protocol for git push on deploy job

### DIFF
--- a/lib/tasks/ci/ssh_repo.rake
+++ b/lib/tasks/ci/ssh_repo.rake
@@ -1,5 +1,5 @@
 directory "vendor/ssh_bundler.github.io" => ["vendor"] do
-  system "git clone https://github.com/rubygems/bundler-site.git vendor/ssh_bundler.github.io"
+  system "git clone git@github.com:rubygems/bundler-site.git vendor/ssh_bundler.github.io"
 end
 
 namespace :ci do


### PR DESCRIPTION
Fixes up #789

While in #789, we changed the protocol from SSH to HTTPS along with changes on the repository (#591), it did not work. This PR reverts the protocol to SSH.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>