### PR TITLE
Use git config prepared by actions/checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Deploy
         run: |
           eval "$(ssh-agent -s)"
+          mkdir -p vendor/ssh_bundler.github.io/.git
+          cp -f .git/config vendor/ssh_bundler.github.io/.git/config
           bundle exec rake ci:deploy
         env:
           encrypted_key: ${{ secrets.encrypted_key }}

--- a/lib/tasks/ci/ssh_repo.rake
+++ b/lib/tasks/ci/ssh_repo.rake
@@ -1,5 +1,5 @@
 directory "vendor/ssh_bundler.github.io" => ["vendor"] do
-  system "git clone git@github.com:rubygems/bundler-site.git vendor/ssh_bundler.github.io"
+  system "git clone https://github.com/rubygems/bundler-site vendor/ssh_bundler.github.io"
 end
 
 namespace :ci do


### PR DESCRIPTION
`actions/checkout` sets up the configuration for authentication to `rubygems/bundler-site` with Read/Write permission. As a workaround until #790 completes, we can use that configuration in `vendor/ssh_bundler.github.io`, copying `git config` (`.git/config`).

Fixes more up #789

Reverts #791

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>