### PR TITLE
Use gh-pages branch on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,6 @@ jobs:
       - name: Deploy
         run: |
           eval "$(ssh-agent -s)"
-          mkdir -p vendor/ssh_bundler.github.io/.git
-          cp -f .git/config vendor/ssh_bundler.github.io/.git/config
           bundle exec rake ci:deploy
         env:
           encrypted_key: ${{ secrets.encrypted_key }}

--- a/lib/tasks/ci/deploy.rake
+++ b/lib/tasks/ci/deploy.rake
@@ -18,20 +18,19 @@ namespace :ci do
     sh "rm deploy_key"
   end
 
-  task deploy: :build do
+  task deploy: [:build, "vendor/ssh_bundler.github.io"] do
     configure_ssh_deploy_key
-
-    Rake::Task["ci:update_ssh_site"].invoke
 
     commit = `git rev-parse HEAD`.chomp
 
     Dir.chdir "vendor/ssh_bundler.github.io" do
-      BRANCH_FOR_PAGES = "gh-pages".freeze
-      sh "git checkout #{BRANCH_FOR_PAGES}"
-
       rm_rf FileList["*"]
       cp_r FileList["../../build/*"], "./"
       File.write("CNAME", "bundler.io")
+
+      # Copy gitconfig prepared by actions/checkout Action from .git/config
+      # to get configuration for `git push`
+      cp "../../.git/config", ".git/config"
 
       sh "git add -A ."
 

--- a/lib/tasks/ci/ssh_repo.rake
+++ b/lib/tasks/ci/ssh_repo.rake
@@ -1,13 +1,12 @@
+BRANCH_FOR_PAGES = "gh-pages".freeze
+
 directory "vendor/ssh_bundler.github.io" => ["vendor"] do
-  system "git clone https://github.com/rubygems/bundler-site vendor/ssh_bundler.github.io"
+  system "git clone --branch #{BRANCH_FOR_PAGES} --single-branch https://github.com/rubygems/bundler-site vendor/ssh_bundler.github.io"
 end
 
 namespace :ci do
   task update_ssh_site: "vendor/ssh_bundler.github.io" do
     Dir.chdir "vendor/ssh_bundler.github.io" do
-      BRANCH_FOR_PAGES = "gh-pages".freeze
-
-      sh "git checkout #{BRANCH_FOR_PAGES}"
       sh "git reset --hard HEAD"
       sh "git pull origin #{BRANCH_FOR_PAGES}"
     end

--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -68,16 +68,16 @@ task repo_pages: :update_vendor do
   end
 end
 
+BRANCH_FOR_PAGES = "gh-pages".freeze
+
 directory "vendor/bundler.github.io" => ["vendor"] do
-  system "git clone https://github.com/rubygems/bundler-site.git vendor/bundler.github.io"
+  system "git clone --branch #{BRANCH_FOR_PAGES} --single-branch https://github.com/rubygems/bundler-site.git vendor/bundler.github.io"
 end
 
 task update_site: "vendor/bundler.github.io" do
   Dir.chdir "vendor/bundler.github.io" do
-    BRANCH_FOR_PAGES = "gh-pages".freeze
-
     sh "git checkout #{BRANCH_FOR_PAGES}"
     sh "git reset --hard HEAD"
-    sh "git pull origin #{BRANCH_FOR_PAGES}"
+    sh "git pull origin HEAD"
   end
 end


### PR DESCRIPTION
Fixes up #789 and #793

Now `ci:deploy` task is independent from `ci:update_ssh_site` task 🎉 

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)