### PR TITLE
Migrate the deploy Action from homemade to the official

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,20 @@ on:
   push:
     branches: [master]
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
-  deploy:
+  # Build job
+  build:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -23,11 +35,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Deploy
-        run: |
-          eval "$(ssh-agent -s)"
-          bundle exec rake ci:deploy
-        env:
-          encrypted_key: ${{ secrets.encrypted_key }}
-          encrypted_iv: ${{ secrets.encrypted_iv }}
-          COMMIT_AUTHOR_EMAIL: team@bundler.io
+      # cf. https://github.com/actions/starter-workflows/blob/4a8f18e34dd13d2b6ee4d8da2ba72629eafe1609/pages/jekyll.yml
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v1
+
+      - run: bundle exec rake build # Output to ./_site as build_dir is configured in config.rb
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1 # This will automatically upload an artifact from the '/_site' directory
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/config.rb
+++ b/config.rb
@@ -21,6 +21,10 @@ end
 
 set :layout, :base
 
+# Easy setup just for deployment for GitHub Pages
+set :build_dir, "_site"
+set :images_dir, "images"
+
 set :markdown_engine, :kramdown
 
 # Markdown extentions
@@ -43,8 +47,6 @@ activate :external_pipeline,
          command: build? ? "npm run build" : "npm run start",
          source: ".tmp/dist",
          latency: 1
-
-set :images_dir, 'images'
 
 # Make documentation for the latest version available at the top level, too.
 # Any pages with names that conflict with files already at the top level will be skipped.


### PR DESCRIPTION
With [the release of Custom GitHub Actions Workflows (beta) for GitHub Pages](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/) on July 27, 2022, we can benefit from it to make the publishing source from `gh-pages` branch to `main` after #591 (= #794 + #789).

Closes #790

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)