### PR TITLE
Enable the custom domain again even in custom workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
 
       - run: bundle exec rake build # Output to ./_site as build_dir is configured in config.rb
 
+      - run: echo "bundler.io" > ./_site/CNAME
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1 # This will automatically upload an artifact from the '/_site' directory
 


### PR DESCRIPTION
Follows up #795

As #795 did not update the contents in `https://bundler.io`, I think no downtime on `bundler.io` happened during #795 and this PR.

- #795