### PR TITLE
Remove operations for SSH key from ci:deploy

### DIFF
--- a/lib/tasks/ci/deploy.rake
+++ b/lib/tasks/ci/deploy.rake
@@ -1,26 +1,9 @@
 namespace :ci do
-  def encrypted_key
-    ENV["encrypted_key"]
-  end
-
-  def encrypted_iv
-    ENV["encrypted_iv"]
-  end
-
   def commit_author_email
     ENV["COMMIT_AUTHOR_EMAIL"]
   end
 
-  def configure_ssh_deploy_key
-    sh "openssl aes-256-cbc -K #{encrypted_key} -iv #{encrypted_iv} -in deploy_key.enc -out deploy_key -d"
-    sh "chmod 600 deploy_key"
-    sh "ssh-add deploy_key"
-    sh "rm deploy_key"
-  end
-
   task deploy: [:build, "vendor/ssh_bundler.github.io"] do
-    configure_ssh_deploy_key
-
     commit = `git rev-parse HEAD`.chomp
 
     Dir.chdir "vendor/ssh_bundler.github.io" do


### PR DESCRIPTION
We do not use SSH key to pull/push the repository due to #591.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)