### PR TITLE
Use i18n locale in html lang

### DIFF
--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html(lang="en")
+%html(lang="#{I18n.locale.to_s}")
   %head
     %meta(charset="utf-8")
     %meta(http-equiv="X-UA-Compatible" content="IE=edge")


### PR DESCRIPTION
We should align with meta tag:
```haml
    %meta(http-equiv="Content-Language" content="#{I18n.locale.to_s}")
```

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)