### PR TITLE
Add the badge of Pages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # bundler.io
+
+[![Middleman deploy](https://github.com/rubygems/bundler-site/actions/workflows/deploy.yml/badge.svg)](https://github.com/rubygems/bundler-site/deployments/activity_log?environment=github-pages)
+
 bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/rubygems/rubygems) gem.
 
 The site bundler.io is a static site generated using [Middleman](http://middlemanapp.com/).


### PR DESCRIPTION
For visibility for contributors. Link target is [the Deployment page](https://github.com/rubygems/bundler-site/deployments/activity_log?environment=github-pages), not [the deploy workflow on Actions](https://github.com/rubygems/bundler-site/actions/workflows/deploy.yml?query=branch%3Amaster).

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)