### PR TITLE
Fix redirection rules for older guides before 1.15

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -115,7 +115,7 @@ end
   next if version == "1.15"
 
   %w[bundler_setup bundler_sharing deploying faq git_bisect git groups rails sinatra updating_gems].each do |filename|
-    redirect "v#{version}/guides/#{filename}.html", to: "v1.15/guides/#{filename}.html"
+    redirect "v#{version}/#{filename}.html", to: "v1.15/guides/#{filename}.html"
   end
 
   # Redirect old localizable guides (v1.12-v1.14) to the latest version (1.15) of guide compatible with Ruby 1.8.x
@@ -125,7 +125,7 @@ end
   end
 end
 %w[rails23 rails3].each do |filename|
-  redirect "v1.12/guides/#{filename}.html", to: "v1.15/guides/#{filename}.html"
+  redirect "v1.12/#{filename}.html", to: "v1.15/guides/#{filename}.html"
 end
 
 # Redirect versioned-guides (which are not localizable) between v1.16 and v2.3 to version-independent guides


### PR DESCRIPTION
`https://bundler.io/v1.12/bundler_setup.html` has not been redirected to `https://bundler.io/v1.15/guides/bundler_setup.html` correctly.

Fixes up #669

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)