### PR TITLE
Clean up application.js around AnchorJS

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,9 +1,2 @@
 import './search';
 import './search_arrows';
-import AnchorJS from 'anchor-js';
-
-const anchors = new AnchorJS();
-
-anchors.options = {
-  visible: 'touch',
-};

--- a/assets/javascripts/two_column_layout.js
+++ b/assets/javascripts/two_column_layout.js
@@ -2,13 +2,17 @@ import AnchorJS from 'anchor-js';
 
 const anchors = new AnchorJS();
 
-const el = document.querySelector('.version-selects');
-el &&
-  el.addEventListener('input', function (e) {
-    document.location.href = e.target.value;
-  });
+anchors.options = {
+  visible: 'touch',
+};
 
 anchors.add(
   '#page-content-wrapper h1, #page-content-wrapper h2, #page-content-wrapper h3, ' +
     '#page-content-wrapper h4, #page-content-wrapper h5'
 );
+
+const el = document.querySelector('.version-selects');
+el &&
+  el.addEventListener('input', function (e) {
+    document.location.href = e.target.value;
+  });


### PR DESCRIPTION
After #806, we can clean up more code around AnchorJS. Now only `assets/javascripts/two_column_layout.js` is using AnchorJS, and so we can move the option there.

Partially removes render-blocking JavaScript. cf. https://www.bryanbraun.com/anchorjs/#dont-run-it-too-late

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)