### PR TITLE
Remove h1 from AnchorJS target

### DIFF
--- a/assets/javascripts/two_column_layout.js
+++ b/assets/javascripts/two_column_layout.js
@@ -3,7 +3,7 @@ import AnchorJS from 'anchor-js';
 const anchors = new AnchorJS();
 
 anchors.add(
-  '#page-content-wrapper h1, #page-content-wrapper h2, #page-content-wrapper h3, ' +
+  '#page-content-wrapper h2, #page-content-wrapper h3, ' +
     '#page-content-wrapper h4, #page-content-wrapper h5'
 );
 


### PR DESCRIPTION
1. AnchorJS has [`h2, h3, h4, h5, h6` as default](https://github.com/bryanbraun/anchorjs/blob/e953150d8e50ebc84f490eb11207845803239234/anchor.js#L89) and follow it. In general, a page has only single `h1` element, so we do not need to use anchor.
2. The site has 51 `h1` tags in 50 files generated by `rake build`.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)