### PR TITLE
Remove h5 elements when they are not necessary

### DIFF
--- a/source/partials/_team_member.haml
+++ b/source/partials/_team_member.haml
@@ -3,6 +3,5 @@
     .polygon-each-img-wrap
       = image_tag "team/#{login}.jpg", class: "polygon-clip-hexagon"
     .card-body.caption.text-center
-      %h4
-        %b= name
-      %h5= link_to "@#{login}", "https://github.com/#{login}"
+      %h4.fw-bold= name
+      .fs-5= link_to "@#{login}", "https://github.com/#{login}"


### PR DESCRIPTION
- Not to use `<b>`.
- Not to use `<h5>`.

`h4` is not changed since CSS is applied to them.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)