### PR TITLE
Remove touch option from AnchorJS

### DIFF
--- a/assets/javascripts/two_column_layout.js
+++ b/assets/javascripts/two_column_layout.js
@@ -2,10 +2,6 @@ import AnchorJS from 'anchor-js';
 
 const anchors = new AnchorJS();
 
-anchors.options = {
-  visible: 'touch',
-};
-
 anchors.add(
   '#page-content-wrapper h1, #page-content-wrapper h2, #page-content-wrapper h3, ' +
     '#page-content-wrapper h4, #page-content-wrapper h5'


### PR DESCRIPTION
This option works no more in many browsers as expected in #218.

- https://caniuse.com/touch
- https://github.com/bryanbraun/anchorjs/issues/168

Closes #816

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://caniuse.com/touch)