### PR TITLE
Support non-default build_dir in a Rack server

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,10 +1,14 @@
-# Modified version of TryStatic, from rack-contrib
-# https://github.com/rack/rack-contrib/blob/master/lib/rack/contrib/try_static.rb
+# frozen_string_literal: true
 
-# Serve static files under a `build` directory:
-# - `/` will try to serve your `build/index.html` file
-# - `/foo` will try to serve `build/foo` or `build/foo.html` in that order
-# - missing files will try to serve build/404.html or a tiny default 404 page
+# Modified version of TryStatic, from rack-contrib
+# https://github.com/rack/rack-contrib/blob/095edc9df5c98f2e731898edd8bb2f48894a4445/lib/rack/contrib/try_static.rb
+
+# Serve static files under a BUILD_DIR directory:
+# - `/` will try to serve your `[BUILD_DIR]/index.html` file
+# - `/foo` will try to serve `BUILD_DIR/foo` or `[BUILD_DIR]/foo.html` in that order
+# - missing files will try to serve `[BUILD_DIR]/404.html`` or a tiny default 404 page
+
+MIDDLEMAN_BUILD_DIR = "build" # set the same value as config[:build_dir] for Middleman
 
 module Rack
   class TryStatic
@@ -29,11 +33,11 @@ module Rack
 end
 
 use Rack::Deflater
-use Rack::TryStatic, root: "build", urls: %w[/], try: [".html", "index.html", "/index.html"]
+use Rack::TryStatic, root: MIDDLEMAN_BUILD_DIR, urls: %w[/], try: [".html", "index.html", "/index.html"]
 
 # Run your own Rack app here or use this one to serve 404 messages:
 run lambda{ |env|
-  not_found_page = File.expand_path("../build/404.html", __FILE__)
+  not_found_page = File.expand_path("../#{MIDDLEMAN_BUILD_DIR}/404.html", __FILE__)
   if File.exist?(not_found_page)
     [ 404, { "Content-Type"  => "text/html"}, [File.read(not_found_page)] ]
   else


### PR DESCRIPTION
Make deployment to Heroku review apps robust to support non-default `build_dir` configuration in Middleman.

Follows up #815 

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)