### PR TITLE
Use h1 instead of h2 for command name in command reference

### DIFF
--- a/lib/tasks/man_generator/strip_pages.rake
+++ b/lib/tasks/man_generator/strip_pages.rake
@@ -15,6 +15,7 @@ namespace :man do
     content.search("#SYNOPSIS").first.next_element.name = "pre"
     content.search("#SYNOPSIS").remove
     content.search("h2, h3").each { |elem| elem.content = titleize(elem.content) }
+    content.search("#NAME").first.name = "h1"
     content.search("#NAME").first.content = command_name
 
     # man_whatis


### PR DESCRIPTION
Use `h1` tag for the command name in command reference, instead of `h2`, which is generated by `ronn`.

## before
![bundler io_v2 3_man_bundle-clean 1 html](https://user-images.githubusercontent.com/10229505/182012324-aedccbce-e3c1-45fd-ad54-78af08881fe6.png)

## after
![4567-rubygems-bundlersite-fd5h6ytcwan ws-us58 gitpod io_v2 3_man_bundle-clean 1 html](https://user-images.githubusercontent.com/10229505/182012322-8cb16c6e-0315-4ca6-8089-3b5b932bb9d8.png)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)