### PR TITLE
Update gitpod workspace with the default

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,0 @@
-FROM gitpod/workspace-ruby-3.1
-
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
-  sudo apt-get install -y nodejs

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,6 @@
-image:
-  file: .gitpod.Dockerfile
+image: gitpod/workspace-full
 tasks:
   - init: |
-      curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
-      sudo apt install -y nodejs
       bundle config set path vendor/bundle
       bundle install
       npm install


### PR DESCRIPTION
Updates #648

As `gitpod-io/workspace-full` image, the default image from gitpod-io/workspace-images is now based on both Ruby 3.1.2 and Node.js 16.x, we do not need to built it by ourselves.

- https://github.com/gitpod-io/workspace-images/pull/889

## Check-list

- [x] Open a new workspace from `https://gitpod.io/#github.com/rubygems/bundler-site/tree/tnir-gitpod` to see the server launches without any special operation
- [x] Stop the workspace opened above and restart it to see the server launches normally without any special operation

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)