### PR TITLE
Remove gem install bundler from getting started

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,8 +14,7 @@ en:
     chat_with_us: Chat With Us
     getting_started: Getting Started
     getting_started_description: |
-      Getting started with bundler is easy! Open a terminal window and run this command:
-    getting_started_description2: |
+      Getting started with bundler is easy!
       Specify your dependencies in a Gemfile in your project's root:
     learn_more_gemfile: "Learn More: Gemfiles"
     bundle_install_description: "Install all of the required gems from your specified sources:"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -10,8 +10,7 @@ es:
       Empezando trabajar en un proyecto es tan simple como <code>bundle install</code>.
     getting_started: Para empezar
     getting_started_description: |
-      ¡Empezando con bundler es fácil! Abre una ventana del terminal y ejecuta este comando:
-    getting_started_description2: |
+      ¡Empezando con bundler es fácil!
       Especifique sus dependencias en un Gemfile en la raíz de su proyecto:
     learn_more_gemfile: "Aprenda más: Gemfiles"
     bundle_install_description: "Instala todas de las gemas necesarias de sus fuentes especificadas:"

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -10,8 +10,7 @@ pl:
       Dzięki temu rozpoczęcie pracy nad projektem to wpisanie <code>bundle install</code> w konsoli.
     getting_started: Jak rozpocząć?
     getting_started_description: |
-      Rozpoczęcie pracy z bundler'em jest bardzo proste! Otwórz terminal i uruchom tą komendę:
-    getting_started_description2: |
+      Rozpoczęcie pracy z bundler'em jest bardzo proste!
       Określ zależności w Gemfile'u znajdującym się w głównym katalogu Twojego projektu:
     learn_more_gemfile: "Zobacz więcej: Gemfiles"
     bundle_install_description: "Instalacja wszystkich potrzebnych gem'ów z określonego źródła:"

--- a/source/guides/getting_started.html.haml
+++ b/source/guides/getting_started.html.haml
@@ -29,12 +29,7 @@ title: Getting Started
   .bullet
     .description
       %p
-        Getting started with bundler is easy! Open a terminal window and run this command:
-    :code
-      $ gem install bundler
-  .bullet
-    .description
-      %p
+        Getting started with bundler is easy!
         Specify your dependencies in a Gemfile in your project's root:
     :code
       # lang: ruby

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -37,11 +37,6 @@
         .description
           %p= t('home.getting_started_description')
         :code
-          $ gem install bundler
-      .bullet
-        .description
-          %p= t('home.getting_started_description2')
-        :code
           # lang: ruby
           source 'https://rubygems.org'
           gem 'nokogiri'


### PR DESCRIPTION
Removes gem install bundler from getting started (in [the top page](https://bundler.io/) and [the dedicated page](https://bundler.io/guides/getting_started.html)).

Last resort for older Ruby's without Bundler bundled is `https://bundler.io/v1.15/guides/using_bundler_in_applications.html` as of writing.

Closes #763 

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)