### PR TITLE
Clean up whats new pages

### DIFF
--- a/lib/templates/whats_new.html.haml.erb
+++ b/lib/templates/whats_new.html.haml.erb
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -21,3 +23,5 @@
       %ul
         %li SMALL NEW THING FIXES A PROBLEM
       = link_to 'Full <%= version %> changelog', 'https://github.com/rubygems/rubygems/blob/<%= rubygems_version %>/bundler/CHANGELOG.md', class: 'btn btn-primary'
+
+= partial "shared/whats_new"

--- a/source/shared/_whats_new.haml
+++ b/source/shared/_whats_new.haml
@@ -1,5 +1,10 @@
-%h1 What's New in each Release
-.row
-  .col-12
-    - versions.reverse.select{ |version| path_exist?('whats_new', version) }.each do |v|
-      = link_to v, "/#{v}/whats_new.html", class: "btn btn-sm #{current_visible_version == v ? 'btn-secondary' : 'btn-primary'}"
+%aside.my-5
+  .container
+    .h4 What's New in other Releases
+    .row
+      .col-12
+        - versions.reverse.select{ |version| path_exist?('whats_new', version) }.each do |v|
+          - if current_visible_version == v
+            %span.btn.btn-sm.btn-secondary= v
+          - else
+            = link_to v, "/#{v}/whats_new.html", class: "btn btn-sm btn-primary"

--- a/source/v1.12/whats_new.html.haml
+++ b/source/v1.12/whats_new.html.haml
@@ -1,9 +1,9 @@
 -# TODO maybe add header?
 
 .container.guide
-  = partial "shared/whats_new"
-
-  %h2#version112 What's New in v1.12
+  %h1
+    What's New in
+    = current_visible_version
 
   %h3 New index format
 
@@ -39,3 +39,5 @@
           %li support for frozen string literals
           %li many, many, many bugfixes
         = link_to 'Full 1.12 changelog', 'https://github.com/bundler/bundler/blob/1-12-stable/CHANGELOG.md', class: 'btn btn-primary'
+
+= partial "shared/whats_new"

--- a/source/v1.13/whats_new.html.haml
+++ b/source/v1.13/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -62,3 +64,5 @@
         %li Support for setting "mirror" servers by hostname
         %li Automatic retrying for gem downloads
       = link_to 'Full 1.13 changelog', 'https://github.com/bundler/bundler/blob/1-13-stable/CHANGELOG.md', class: 'btn btn-primary'
+
+= partial "shared/whats_new"

--- a/source/v1.14/whats_new.html.haml
+++ b/source/v1.14/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -48,3 +50,5 @@
         %li The output from `bundle env` is now preformatted as Markdown for pasting into a GitHub issue.
         %li After Bundler 2.0 is (eventually) released, Bundler 1.14 and greater will be able to automatically switch to Bundler 2.0+ for apps that need it.
       = link_to 'Full 1.14 changelog', 'https://github.com/bundler/bundler/blob/1-14-stable/CHANGELOG.md', class: 'btn btn-primary'
+
+= partial "shared/whats_new"

--- a/source/v1.15/whats_new.html.haml
+++ b/source/v1.15/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -34,3 +36,5 @@
       .description
         %p
           Just like the `gem pristine` command, the `bundle pristine` command wipes out any changes you have made to the gems installed locally, for testing or debugging reasons, and restores them to a freshly-installed state.
+
+= partial "shared/whats_new"

--- a/source/v1.16/whats_new.html.haml
+++ b/source/v1.16/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -30,3 +32,5 @@
         %li gemfiles are evaluated one fewer time when running `bundle install`
         %li More than 20 other bugfixes
       = link_to 'Full 1.16 changelog', 'https://github.com/bundler/bundler/blob/1-16-stable/CHANGELOG.md', class: 'btn btn-primary'
+
+= partial "shared/whats_new"

--- a/source/v1.17/whats_new.html.haml
+++ b/source/v1.17/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -68,5 +70,4 @@
 
           To change the directory where Bundler will store all user-level files (which is <code>~/.bundle</code> by default), set <code>BUNDLE_USER_HOME</code>. To change the directory where Bundler caches downloaded gems and gem metadata (which is <code>~/.bundle/cache</code> by default), set <code>BUNDLE_USER_CACHE</code>. To change the location of the user-level configuration file (which is <code>~/.bundle/config</code> by default), set <code>BUNDLE_USER_CONFIG</code>. Finally, to set the location that Bundler will look for plugin files (which is <code>~/.bundle/plugins</code> by default), set <code>BUNDLE_USER_PLUGIN</code>.
 
-
-
+= partial "shared/whats_new"

--- a/source/v2.0/whats_new.html.haml
+++ b/source/v2.0/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -24,3 +26,5 @@
             Errors/warnings will now print to <code>STDERR</code>
           %li
             Bundler now auto-switches between version 1 and 2 based on the Lockfile
+
+= partial "shared/whats_new"

--- a/source/v2.1/whats_new.html.haml
+++ b/source/v2.1/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     This time there was not blog post announcement for the 2.1 release, but as
@@ -334,3 +336,5 @@
             %p
               In general, we don't want to maintain integrations for every
               deployment system out there, so that's why we are removing these.
+
+= partial "shared/whats_new"

--- a/source/v2.2/whats_new.html.haml
+++ b/source/v2.2/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -38,3 +40,5 @@
           default gem, and dozens of bug fixes
 
       = link_to 'Full 2.2 changelog', 'https://github.com/rubygems/rubygems/blob/3.2/bundler/CHANGELOG.md', class: 'btn btn-primary'
+
+= partial "shared/whats_new"

--- a/source/v2.3/whats_new.html.haml
+++ b/source/v2.3/whats_new.html.haml
@@ -1,5 +1,7 @@
 .container.guide
-  = partial "shared/whats_new"
+  %h1
+    What's New in
+    = current_visible_version
 
   %p
     The
@@ -29,3 +31,5 @@
           smoother.
 
       = link_to 'Full 2.3 changelog', 'https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md', class: 'btn btn-primary'
+
+= partial "shared/whats_new"


### PR DESCRIPTION
Moves the navigation to what's new pages in other versions to bottom and adds the `h1` heading titled as `What's New in vX.Y`.

Closes #827

| before | after |
|-|-|
| ![bundler io_v1 12_whats_new html](https://user-images.githubusercontent.com/10229505/182031308-6f372dfd-ce27-43f5-b301-8f72fe81b50f.png) | ![4567-rubygems-bundlersite-xaimk8cdg5n ws-us58 gitpod io_v1 12_whats_new html](https://user-images.githubusercontent.com/10229505/182032483-a82baeb9-7cd1-4855-a23a-c86d290dda73.png) |

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)