### PR TITLE
Use full build to test man, repo page, contributors build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: bundle exec middleman build
+      - name: Build everything from scratch
+        run: bundle exec rake build
         env:
           NO_CONTRACTS: "true"


### PR DESCRIPTION
Updates #493

We should check if all builds pass. `rake build` triggers `contributors:update`, `repo_pages`, `man` tasks before `middleman build`.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)