### PR TITLE
Use h1 in bundle plugin

### DIFF
--- a/source/v2.1/bundle_plugin.html.haml
+++ b/source/v2.1/bundle_plugin.html.haml
@@ -1,4 +1,8 @@
-%h2 bundle plugin
+---
+title: bundle plugin
+description: bundle-plugin allows you to manage Bundler plugins.
+---
+%h1 bundle plugin
 
 .contents
   .bullet

--- a/source/v2.2/bundle_plugin.html.haml
+++ b/source/v2.2/bundle_plugin.html.haml
@@ -1,4 +1,8 @@
-%h2 bundle plugin
+---
+title: bundle plugin
+description: bundle-plugin allows you to manage Bundler plugins.
+---
+%h1 bundle plugin
 
 .contents
   .bullet

--- a/source/v2.3/bundle_plugin.html.haml
+++ b/source/v2.3/bundle_plugin.html.haml
@@ -1,4 +1,8 @@
-%h2 bundle plugin
+---
+title: bundle plugin
+description: bundle-plugin allows you to manage Bundler plugins.
+---
+%h1 bundle plugin
 
 .contents
   .bullet


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Headings in `bundle plugin` (https://bundler.io/v2.3/bundle_plugin.html for v2.3) are `h2` tag instead of `h1`, which is the standard formatting.

Also meta description is missing.

Closes #832

### What was your diagnosis of the problem?

Replace h2 with h1 in the command title.

Add meta description for SEO.

### What is your fix for the problem, implemented in this PR?

Use h1 in bundle plugin (only v2.1 through v2.3).

### Why did you choose this fix out of the possible options?

We could migrate this doc to rubygems/rubygems, but I do not think it is so easy to do so against v2.1 and v2.2.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/tnir)