### PR TITLE
Remove anchors unused for 6 years from Rails guides

### DIFF
--- a/source/guides/rails.html.haml
+++ b/source/guides/rails.html.haml
@@ -51,7 +51,7 @@ title: How to use Bundler with Rails
           gem 'rspec'
           gem 'faker'
         end
-    .bullet#shared_with_23
+    .bullet
       .description
         You can place a dependency in multiple groups
         at once as well

--- a/source/v1.15/guides/rails.html.haml
+++ b/source/v1.15/guides/rails.html.haml
@@ -51,7 +51,7 @@ title: Using Bundler with Rails
           gem 'rspec'
           gem 'faker'
         end
-    .bullet#shared_with_23
+    .bullet
       .description
         You can place a dependency in multiple groups
         at once as well


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Anchors unused for 6 years in Rails guides (https://bundler.io/guides/rails.html etc.) violates HAML-Lint, which blocks #860.

Closes #861

Updates #257

Blocks #860

### What was your diagnosis of the problem?

It is confirmed that no internal reference has existed for 6 years i.e., #257.

### What is your fix for the problem, implemented in this PR?

Removes these anchors from Rails guides https://bundler.io/guides/rails.html and https://bundler.io/v1.15/guides/rails.html.

### Why did you choose this fix out of the possible options?

No other options to us.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
