### PR TITLE
Avoid to use vulnerable gem as examples

### DIFF
--- a/source/guides/bundler_2_upgrade.html.md
+++ b/source/guides/bundler_2_upgrade.html.md
@@ -26,7 +26,7 @@ Here's an example Gemfile.lock that was created with Bundler 1.17.1.
     GEM
       remote: https://rubygems.org/
       specs:
-        rack (2.0.6)
+        rack (2.2.4)
 
     PLATFORMS
       ruby

--- a/source/guides/bundler_workflow.html.haml
+++ b/source/guides/bundler_workflow.html.haml
@@ -71,7 +71,7 @@
         # lang: ruby
         source 'https://rubygems.org'
         gem 'nokogiri'
-        gem 'rack', '~> 2.0.1'
+        gem 'rack', '~> 2.2.4'
         gem 'rspec'
 
       .notes
@@ -108,7 +108,7 @@
               Using builder 3.2.2
               Using erubis 2.7.0
               Using mini_portile2 2.1.0
-              Using rack 2.0.1
+              Using rack 2.2.4
               Using nio4r 1.2.1
               Using websocket-extensions 0.1.2
               Installing mime-types-data 3.2016.0521

--- a/source/guides/getting_started.html.haml
+++ b/source/guides/getting_started.html.haml
@@ -35,7 +35,7 @@ title: Getting Started
       # lang: ruby
       source 'https://rubygems.org'
       gem 'nokogiri'
-      gem 'rack', '~> 2.0.1'
+      gem 'rack', '~> 2.2.4'
       gem 'rspec'
     = link_to 'Learn More: Gemfiles', './gemfile.html', class: 'btn btn-primary'
 

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -40,7 +40,7 @@
           # lang: ruby
           source 'https://rubygems.org'
           gem 'nokogiri'
-          gem 'rack', '~> 2.0.1'
+          gem 'rack', '~> 2.2.4'
           gem 'rspec'
         %p.text-center.text-md-end
           = link_to t('home.learn_more_gemfile'), './gemfile.html', class: 'btn btn-primary btn-lg btn-responsive'

--- a/source/v1.15/guides/git.html.haml
+++ b/source/v1.15/guides/git.html.haml
@@ -58,9 +58,9 @@ title: Gems from git repositories
         exactly the same way
       :code
         # lang: ruby
-        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :ref => '0bd839d'
-        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :tag => '2.0.1'
-        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :branch => 'rack-1.5'
+        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :ref => '293b8e7'
+        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :tag => '2.2.4'
+        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :branch => '2-2-stable'
     .bullet
       .description
         Bundler can use HTTP(S), SSH, or git


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

rack 2.2.3 and earlier has CVE-2022-30123: https://groups.google.com/g/ruby-security-ann/c/LWB10kWzag8

### What was your diagnosis of the problem?

Avoid to suggest to use rack version without vulnerabilities as an example.

### What is your fix for the problem, implemented in this PR?

Update rack to 2.2.4 in all the examples.

### Why did you choose this fix out of the possible options?

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
