### PR TITLE
Enable HtmlAttributes for all files in HAML-Lint

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,10 +1,6 @@
 skip_frontmatter: true
 
 linters:
-  HtmlAttributes:
-    exclude:
-      - "source/layouts/base.haml"
-
   IdNames:
     exclude:
       - "source/guides/bundler_plugins.html.haml"

--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -1,11 +1,11 @@
 !!! 5
-%html(lang="#{I18n.locale.to_s}")
+%html{ lang: I18n.locale }
   %head
-    %meta(charset="utf-8")
-    %meta(http-equiv="X-UA-Compatible" content="IE=edge")
-    %meta(http-equiv="Content-Language" content="#{I18n.locale.to_s}")
-    %meta(name="viewport" content="width=device-width, initial-scale=1")
-    %meta(name="globalsign-domain-verification" content="276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL")
+    %meta{ charset: "utf-8" }
+    %meta{ "http-equiv": "X-UA-Compatible", content: "IE=edge" }
+    %meta{ "http-equiv": "Content-Language", content: I18n.locale }
+    %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
+    %meta{ name: "globalsign-domain-verification", content: "276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL" }
     %title
       - page_title = current_page.data.title
       = "Bundler: #{ page_title || "The best way to manage a Ruby application's gems" }"
@@ -13,7 +13,7 @@
     = yield_content :head
 
     - if content_for?(:canonical)
-      %link(rel="canonical" href="#{yield_content(:canonical)}")
+      %link{ rel: "canonical", href: yield_content(:canonical) }
 
     = javascript_include_tag "application.min"
     = stylesheet_link_tag "application"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Some linters were disabled when HAML-Lint was introduced in #776.

### What was your diagnosis of the problem?

`HtmlAttributes` HAML linter can be enabled for all files.

### What is your fix for the problem, implemented in this PR?

Removes exclusion of files with lints and enables the linter.

### Why did you choose this fix out of the possible options?

n/a

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/tnir)