### PR TITLE
Enable RepeatedId for all files in HAML-Lint

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -20,10 +20,6 @@ linters:
   LineLength:
     max: 849
 
-  RepeatedId:
-    exclude:
-      - "source/guides/bundler_plugins.html.haml"
-
   RuboCop:
     enabled: true
     ignored_cops:


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`RepeatedId` linter in HAML-Lint was not enabled in #776.

### What was your diagnosis of the problem?

#863 addressed lints against `RepeatedId`.

### What is your fix for the problem, implemented in this PR?

Enables `RepeatedId` for all files in HAML-Lint.

### Why did you choose this fix out of the possible options?

n/a

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/tnir)
