### PR TITLE
Remove some CSS selectors with tweaks around them

### DIFF
--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -88,20 +88,6 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
   font-size: 19px;
 }
 
-.btn {
-  margin-top: 10px;
-  margin-bottom: 35px;
-}
-
-@include media-breakpoint-down(sm) {
-  .btn-responsive {
-    font-size: 100%;
-    text-align: center;
-    float: none !important;
-  }
-
-}
-
 .content-padding {
   padding: 30px 2%;
 }
@@ -147,6 +133,9 @@ p {
 
   .btn {
     font-size: 17px;
+    // TODO: remove these two lines
+    margin-top: 10px;
+    margin-bottom: 35px;
 
     @include media-breakpoint-up(lg) {
       font-size: 18px;

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -6,16 +6,16 @@
       width: 1120,
       height: 704
 
-.container
-  .mx-xl-5.px-xl-5.my-5.large-font
+.container.py-5
+  .mx-xl-5.px-xl-5.my-4.large-font
     %p= t('home.bundler_info1')
     %p= t('home.bundler_info2')
 
-  %p.mx-xl-5.text-center
-    = link_to t('home.what_can_bundler_do'), "/guides/getting_started.html#getting-started", class: 'btn btn-primary btn-lg btn-responsive'
-    = link_to "#{t("home.new_in")} #{current_version}", '/whats_new.html', class: 'btn btn-primary btn-lg btn-responsive'
-    = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg btn-responsive'
-    = link_to t('home.chat_with_us'), 'http://slack.bundler.io', class: 'btn btn-primary btn-lg btn-responsive'
+  .d-grid.d-md-flex.gap-2.mx-auto.my-md-4.justify-content-md-center
+    = link_to t('home.what_can_bundler_do'), "/guides/getting_started.html#getting-started", class: 'btn btn-primary btn-lg'
+    = link_to "#{t("home.new_in")} #{current_version}", '/whats_new.html', class: 'btn btn-primary btn-lg'
+    = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
+    = link_to t('home.chat_with_us'), 'http://slack.bundler.io', class: 'btn btn-primary btn-lg'
 
 .bg-light-blue
   .container
@@ -42,8 +42,8 @@
           gem 'nokogiri'
           gem 'rack', '~> 2.2.4'
           gem 'rspec'
-        %p.text-center.text-md-end
-          = link_to t('home.learn_more_gemfile'), './gemfile.html', class: 'btn btn-primary btn-lg btn-responsive'
+        .d-grid.d-md-flex.gap-2.my-3.justify-content-md-end
+          = link_to t('home.learn_more_gemfile'), './gemfile.html', class: 'btn btn-primary btn-lg'
 
       .bullet
         .description
@@ -51,19 +51,18 @@
         :code
           $ bundle install
           $ git add Gemfile Gemfile.lock
-        %p.text-center.text-md-end
-          = link_to t('home.learn_more_bundle_install'), "./#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg btn-responsive'
+        .d-grid.d-md-flex.gap-2.my-3.justify-content-md-end
+          = link_to t('home.learn_more_bundle_install'), "./#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
 
 .bg-light-blue
   .container
     .mx-xl-5.px-xl-5
       %h2#get-involved Get involved
-      .large-font
+      .my-4.large-font
         Bundler has a lot of contributors and users, and we would love to have your help! If you have questions, join #{link_to 'the Bundler Slack', 'http://slack.bundler.io'} and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with #{link_to 'the contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you think you've found a security issue, please report it via #{link_to 'HackerOne', 'https://hackerone.com/rubygems'}.
 
-      .contents
-        .buttons
-          = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary'
-          = link_to 'Join the Bundler Slack', 'http://slack.bundler.io', class: 'btn btn-primary'
-          = link_to 'Contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary'
-          = link_to 'Report security issue', 'https://hackerone.com/rubygems', class: 'btn btn-primary'
+      .d-grid.d-md-flex.gap-2.mx-auto.my-md-4.justify-content-md-center
+        = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary btn-lg'
+        = link_to 'Join the Bundler Slack', 'http://slack.bundler.io', class: 'btn btn-primary btn-lg'
+        = link_to 'Contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary btn-lg'
+        = link_to 'Report security issue', 'https://hackerone.com/rubygems', class: 'btn btn-primary btn-lg'


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

https://github.com/rubygems/bundler-site/pull/218/commits/8bdc09ee50bda18107e1532bca69c126d9486ccd introduced hard-coded `.btn` and `.btn-responsive` in #218, but they have been conflicted with general specifications and the framework (i.e., Bootstrap 5).

- Follows up #785
- Follows up #644

### What was your diagnosis of the problem?

We can remove them for now as the major framework migration was done in #681.

### What is your fix for the problem, implemented in this PR?

Removes CSS selectors `.btn` and `.btn-responsive` with spacing tweaks around these occurrences mainly to make these buttons fully responsive on the top page besides removal of the technical debt. Some are what #218 intended to achieve, but failed.

Note that this change affects only the top page.

| Screen width / px | Before | After |
|-|-|-|
| 320 | ![bundler io_w320](https://user-images.githubusercontent.com/10229505/187033899-d59d5b9c-c689-4ec5-9f48-79973cda967d.png) | ![after_w320](https://user-images.githubusercontent.com/10229505/187033901-5a3109e6-c348-401d-8036-b003021bfc91.png) |
| 768 | ![bundler io_w768](https://user-images.githubusercontent.com/10229505/187033898-8c740e1d-415d-417a-b741-cd13f3d77008.png) | ![after_w768](https://user-images.githubusercontent.com/10229505/187033903-89ca3fc4-199c-41a5-9774-cb9c832bb2cf.png) |
| 1180 | ![bundler io_w1180](https://user-images.githubusercontent.com/10229505/187033894-04528099-7fb7-46c6-8ba4-2737393fbc0a.png) | ![after_w1180](https://user-images.githubusercontent.com/10229505/187033908-f1ed2ece-9366-4d1d-864b-515ce9302354.png) |

### Why did you choose this fix out of the possible options?

n/a

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
