### PR TITLE
Remove source/older_versions.html.haml

### DIFF
--- a/source/older_versions.html.haml
+++ b/source/older_versions.html.haml
@@ -1,9 +1,0 @@
----
-title: Older Versions of Bundler
----
-.container
-  %h2 Older Versions of Bundler
-  .row
-    .col-12.text-center
-      - versions.reverse.select{ |version| path_exist?('docs', version) || path_exist?('index', version) }.each do |v|
-        = link_to v, "/#{v}/#{path_exist?('docs', v) ? 'docs' : 'index'}.html", class: "btn btn-sm #{current_visible_version == v ? 'btn-secondary' : 'btn-primary'}"


### PR DESCRIPTION
`/older_versions` is now redirected to `/whats_new` since #687.

- Follows up #687
- Closes #897

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>