### PR TITLE
Bump rb-fsevent from 0.11.1 to 0.11.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     rack (2.2.4)
     rainbow (3.1.1)
     rake (13.0.6)
-    rb-fsevent (0.11.1)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rdiscount (2.2.0.2)


### PR DESCRIPTION
https://my.diffend.io/gems/rb-fsevent/0.11.1/0.11.2

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)