### PR TITLE
Update activesupport from 6.1.6.1 to 7.0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 ruby File.read(File.expand_path("../.ruby-version", __FILE__)).strip
 
 # Static site generator
-gem "activesupport", "~> 6.1" # middleman 5.x allows us to use activesupport 7.x but stay with 6.1 at this moment
 ## See https://github.com/middleman/middleman/pull/2565
 gem "middleman", github: "tnir/middleman", branch: "delegate-each_with_index-sitemap-resourcelistcontainer"
 ## Extensions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,12 +51,11 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.6.1)
+    activesupport (7.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
@@ -196,7 +195,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
     webrick (1.7.0)
-    zeitwerk (2.6.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -204,7 +202,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (~> 6.1)
   builder
   haml (~> 5.2.2)
   haml_lint (~> 0.40)


### PR DESCRIPTION
Unlocks activesupport version.

Follows up #905 and #901

## Refs.

- #905
- #901
- https://github.com/middleman/middleman/pull/2552

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)