### PR TITLE
Remove messy CSS tweaks introduced from Simple Sidebar

### DIFF
--- a/assets/stylesheets/_sidebar.scss
+++ b/assets/stylesheets/_sidebar.scss
@@ -4,13 +4,6 @@
  * Licensed under MIT (https://github.com/BlackrockDigital/startbootstrap/blob/gh-pages/LICENSE)
  */
 
-#sidebar-wrapper {
-  -webkit-transition: all 0.5s ease;
-  -moz-transition: all 0.5s ease;
-  -o-transition: all 0.5s ease;
-  transition: all 0.5s ease;
-}
-
 /* Sidebar Styles */
 
 .sidebar-nav {

--- a/source/layouts/two_column_layout.haml
+++ b/source/layouts/two_column_layout.haml
@@ -21,7 +21,7 @@
     .row.flex-column.flex-md-row-reverse
       .col-12.col-md-9.contents#page-content-wrapper{ class: is_command ? "commands" : "guide" }
         ~ yield
-      .col-12.col-md-3.mt-4#sidebar-wrapper
+      .col-12.col-md-3.mt-4
         .sidebar-nav
           - if is_command
             = partial 'partials/commands_sidebar'


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

CSS animation in sidebar introduced from [Simple Sidebar](https://startbootstrap.com/template/simple-sidebar) in #218 is not semantic.

### What was your diagnosis of the problem?

#### before
https://user-images.githubusercontent.com/10229505/188497467-67769b4e-f131-4cd7-b022-13e8c0f0e22a.mov

### What is your fix for the problem, implemented in this PR?

Removes that CSS tweak and the the relevant identifier.

#### after

https://user-images.githubusercontent.com/10229505/188499371-0aa07bb7-ec13-4cb7-9a37-8ee4c39578a6.mov

### Why did you choose this fix out of the possible options?

n/a

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

