### PR TITLE
haml 6.0.0.beta.2 does not work with middleman even 5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,11 @@ gem "middleman", github: "middleman/middleman", ref: "50f76c2984c4f82b243b0a5e3f
 ## Extensions
 gem "middleman-blog"
 gem "middleman-search", github: "tnir/middleman-search", branch: "edge" # https://github.com/manastech/middleman-search/pull/39
-gem "middleman-syntax"
+gem "middleman-syntax", github: "tnir/middleman-syntax", branch: "haml-6.x" # https://github.com/middleman/middleman-syntax/pull/81
 
 ## Template engines
 gem "builder"
-gem "haml", "~> 5.2.2"
+gem "haml", ">= 6.0.0.beta.2"
 gem "kramdown"
 
 # Rake tasks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,15 @@ GIT
       mini_racer (~> 0.5)
       nokogiri (~> 1.6)
 
+GIT
+  remote: https://github.com/tnir/middleman-syntax.git
+  revision: 7bb2b42e5af96223100c104f2553abf987af0098
+  branch: haml-6.x
+  specs:
+    middleman-syntax (4.0.0.alpha.1)
+      middleman-core (>= 3.2)
+      rouge (~> 3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -79,8 +88,9 @@ GEM
       faraday (~> 2.0)
     fastimage (2.2.6)
     ffi (1.15.5)
-    haml (5.2.2)
-      temple (>= 0.8.0)
+    haml (6.0.0.beta.2)
+      temple (>= 0.8.2)
+      thor
       tilt
     haml_lint (0.43.0)
       haml (>= 4.0, < 6.2)
@@ -110,9 +120,6 @@ GEM
       addressable (~> 2.3)
       middleman-core (>= 4.0.0)
       tzinfo (>= 0.3.0)
-    middleman-syntax (3.3.0)
-      middleman-core (>= 3.2)
-      rouge (~> 3.2)
     mini_portile2 (2.8.0)
     mini_racer (0.6.3)
       libv8-node (~> 16.10.0.0)
@@ -203,13 +210,13 @@ PLATFORMS
 DEPENDENCIES
   builder
   faraday-retry (~> 2.0)
-  haml (~> 5.2.2)
+  haml (>= 6.0.0.beta.2)
   haml_lint (~> 0.43)
   kramdown
   middleman!
   middleman-blog
   middleman-search!
-  middleman-syntax
+  middleman-syntax!
   nokogiri (~> 1.13)
   nronn
   octokit (~> 6.0)


### PR DESCRIPTION
HAML 6.x (at least [haml 6.0.0.beta.2](https://rubygems.org/gems/haml/versions/6.0.0.beta.2) or haml 6.0.1) does not work with middleman even 5.x (unreleased) since middleman-syntax latest (3.3.0) does not support haml 6.x (see https://github.com/middleman/middleman-syntax/issues/80).

```
/home/runner/work/bundler-site/bundler-site/vendor/bundle/ruby/3.1.0/gems/middleman-syntax-3.3.0/lib/middleman-syntax/haml_monkey_patch.rb:4:in `<module:Haml>': Filters is not a module (TypeError)
```

### Refs.

- https://github.com/middleman/middleman-syntax/issues/80