### PR TITLE
Prefer h1 over h2 for the most top-level headings

### DIFF
--- a/source/v1.12/bundle_console.html.md
+++ b/source/v1.12/bundle_console.html.md
@@ -3,7 +3,7 @@ title: bundle console
 description: Start an interactive Ruby console session in the context of the current bundle
 ---
 
-## bundle console
+# bundle console
 
 Start an interactive Ruby console session in the context of the current bundle
 

--- a/source/v1.12/bundle_help.html.md
+++ b/source/v1.12/bundle_help.html.md
@@ -3,7 +3,7 @@ title: bundle help
 description: Displays detailed help for each subcommand on your command line
 ---
 
-## bundle help
+# bundle help
 
 Displays detailed help for each subcommand on your command line
 

--- a/source/v1.13/bundle_console.html.haml
+++ b/source/v1.13/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v1.13/bundle_help.html.haml
+++ b/source/v1.13/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet

--- a/source/v1.14/bundle_console.html.haml
+++ b/source/v1.14/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v1.14/bundle_help.html.haml
+++ b/source/v1.14/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet

--- a/source/v1.15/bundle_console.html.haml
+++ b/source/v1.15/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v1.15/bundle_help.html.haml
+++ b/source/v1.15/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet

--- a/source/v1.16/bundle_console.html.haml
+++ b/source/v1.16/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v1.16/bundle_help.html.haml
+++ b/source/v1.16/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet

--- a/source/v1.17/bundle_console.html.haml
+++ b/source/v1.17/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v1.17/bundle_help.html.haml
+++ b/source/v1.17/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet

--- a/source/v2.0/bundle_console.html.haml
+++ b/source/v2.0/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v2.0/bundle_help.html.haml
+++ b/source/v2.0/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet

--- a/source/v2.1/bundle_console.html.haml
+++ b/source/v2.1/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v2.1/bundle_help.html.haml
+++ b/source/v2.1/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet

--- a/source/v2.2/bundle_console.html.haml
+++ b/source/v2.2/bundle_console.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle console
+%h1 bundle console
 
 .contents
   .bullet

--- a/source/v2.2/bundle_help.html.haml
+++ b/source/v2.2/bundle_help.html.haml
@@ -1,4 +1,4 @@
-%h2 bundle help
+%h1 bundle help
 
 .contents
   .bullet


### PR DESCRIPTION
This standardized consistency in marking up would offer readability as well as a better search experience.

- Closes #836
- Closes #919

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)