### PR TITLE
Replace links to bundler/bundler with appropriate things

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -176,7 +176,7 @@ page /\/v(.*)\/man\/(.*)/, layout: :two_column_layout
 page /\/man\/(.*)/, layout: :two_column_layout
 page /\/v(.*)\/guides\/(.*)/, layout: :two_column_layout
 page /guides\/(.*)/, layout: :two_column_layout
-page /\/doc\/(.*)/, layout: :two_column_layout # Imported from bundler/bundler
+page /\/doc\/(.*)/, layout: :two_column_layout # Imported from rubygems/bundler
 
 page "/sitemap.xml", layout: false
 

--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -39,7 +39,7 @@ end
 
 directory "vendor"
 directory "vendor/bundler" => ["vendor"] do
-  system "git clone --depth 1 --no-single-branch https://github.com/bundler/bundler.git vendor/bundler"
+  system "git clone --depth 1 --no-single-branch https://github.com/rubygems/bundler.git vendor/bundler"
 end
 
 directory "vendor/rubygems" => ["vendor"] do

--- a/source/blog/2016-04-28-the-new-index-format-fastly-and-bundler-1-12.html.md
+++ b/source/blog/2016-04-28-the-new-index-format-fastly-and-bundler-1-12.html.md
@@ -33,4 +33,4 @@ We added a bunch of other small tweaks, features, and bugfixes, so be sure to ch
 
 ## Updating
 
-To get the newest version of Bundler, run `gem install bundler`. If you have any issues, please check out our [issues guide](https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md) and let us know!
+To get the newest version of Bundler, run `gem install bundler`. If you have any issues, please check out our [issues guide](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md) and let us know!

--- a/source/blog/2016-09-08-bundler-1-13.html.md
+++ b/source/blog/2016-09-08-bundler-1-13.html.md
@@ -62,11 +62,11 @@ First, export the environment variable `BUNDLE_ENABLE_TRAMPOLINE`. In the Bash s
 
 #### Experimental conservative updates
 
-`bundle update` received some new options to support conservative updates: `--patch` and `--minor`. "Conservative" meaning it will sort all available versions to prefer the latest patch releases from the current version, then the latest minor releases and then the latest major releases. These aren't documented or formally supported yet while we allow the community some opportunity to weigh in on how these options should work. [Join the discussion and give us your 2 cents so we can lock this in for 1.14](https://github.com/bundler/bundler-features/issues/122). There's even some outstanding issues you can contribute to!
+`bundle update` received some new options to support conservative updates: `--patch` and `--minor`. "Conservative" meaning it will sort all available versions to prefer the latest patch releases from the current version, then the latest minor releases and then the latest major releases. These aren't documented or formally supported yet while we allow the community some opportunity to weigh in on how these options should work. [Join the discussion and give us your 2 cents so we can lock this in for 1.14](https://github.com/rubygems/bundler-features/issues/122). There's even some outstanding issues you can contribute to!
 
 #### Feedback for experimental features
 
-These features are a really big deal, and we want to launch them at the same level of polish and stability that you're used to getting from Bundler. We'll get there, and when we do these features will be turned on by default. In the meantime, if you'd like to try them out, that would be awesome. We'd love to [hear your feedback](https://github.com/bundler/bundler/issues/new). <3
+These features are a really big deal, and we want to launch them at the same level of polish and stability that you're used to getting from Bundler. We'll get there, and when we do these features will be turned on by default. In the meantime, if you'd like to try them out, that would be awesome. We'd love to [hear your feedback](https://github.com/rubygems/rubygems/issues/new/choose). <3
 
 ### How To Upgrade
 

--- a/source/blog/2018-01-08-monthly-update-for-december-and-yearly-update-for-2017.html.markdown
+++ b/source/blog/2018-01-08-monthly-update-for-december-and-yearly-update-for-2017.html.markdown
@@ -9,7 +9,7 @@ Welcome to the Bundler monthly (and yearly) update! We've been writing monthly u
 
 As you may have noticed, [Bundler didn’t end up shipping with Ruby 2.5](https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/). The Ruby language core team has yet to announce why they decided to remove Bundler a few hours before Ruby 2.5 was released on Christmas Day. Hopefully, we’ll find out the story there soon.
 
-In the meantime, Bundler 1.16.1 has been released, with fixes or workarounds for all known issues. If you were waiting to upgrade to version 1.16, give it a try now! If you’re still seeing issues on version 1.16.1, please [let us know!](https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md) We care a lot about fixing bugs and maintaining backwards compatibility, but we need to hear from users in order to know when bugs have crept in. &lt;3
+In the meantime, Bundler 1.16.1 has been released, with fixes or workarounds for all known issues. If you were waiting to upgrade to version 1.16, give it a try now! If you’re still seeing issues on version 1.16.1, please [let us know!](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md) We care a lot about fixing bugs and maintaining backwards compatibility, but we need to hear from users in order to know when bugs have crept in. &lt;3
 
 In December, Bundler gained 59 new commits, contributed by 8 authors. There were 419 additions and 301 deletions across 36 files.
 

--- a/source/blog/2019-01-03-announcing-bundler-2.html.markdown
+++ b/source/blog/2019-01-03-announcing-bundler-2.html.markdown
@@ -69,7 +69,7 @@ If you have more questions, or want more information about Bundler 2, read our [
 
 ### I tried to upgrade but something is broken!
 
-Oh no! Sorry about that. Please head over to our [troubleshooting guide](https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md) and open a ticket so that we can try to fix your problem ASAP.
+Oh no! Sorry about that. Please head over to our [troubleshooting guide](/doc/troubleshooting.html) and open a ticket so that we can try to fix your problem ASAP.
 
 ---- 
 

--- a/source/guides/bundler_plugins.html.haml
+++ b/source/guides/bundler_plugins.html.haml
@@ -194,7 +194,7 @@ title: How to write a Bundler plugin
       %p
         It is recommended to get familiar with the API for <code>Bundler::Plugin::API::Source</code> which is available
 
-        = link_to 'on rubydoc.info', 'https://www.rubydoc.info/github/bundler/bundler/Bundler/Plugin/API/Source'
+        = link_to 'on rubydoc.info', 'https://www.rubydoc.info/gems/bundler/Bundler/Plugin/API/Source'
 
         or
 

--- a/source/guides/git_bisect.html.md
+++ b/source/guides/git_bisect.html.md
@@ -33,4 +33,4 @@ git reset --hard HEAD
 exit $status
 ~~~
 
-See also the discussion at [bundler/bundler#3726](https://github.com/rubygems/bundler/issues/3726).
+See also the discussion at [rubygems/bundler#3726](https://github.com/rubygems/bundler/issues/3726).

--- a/source/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -431,7 +431,7 @@ If none of these instructions fixed the problem, the next step is to open an iss
 
 (Create an issue in the [RubyGems issue tracker](https://github.com/rubygems/rubygems/issues)
 if your error came from `gem install`. If it came from `bundle install`, create an issue in
-the [Bundler issue tracker](https://github.com/bundler/bundler).)
+the [Bundler issue tracker](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md).)
 
 Please include:
 

--- a/source/v1.15/guides/git_bisect.html.md
+++ b/source/v1.15/guides/git_bisect.html.md
@@ -33,4 +33,4 @@ git reset --hard HEAD
 exit $status
 ~~~
 
-See also the discussion at [bundler/bundler#3726](https://github.com/rubygems/bundler/issues/3726).
+See also the discussion at [rubygems/bundler#3726](https://github.com/rubygems/bundler/issues/3726).


### PR DESCRIPTION
With this PR, there will be the only one occurrence of `bundler/bundler`, which can be left alone as it is just a history.

```
$ git grep bundler/bundler
source/blog/2020-04-27-march-monthly-update.html.markdown:[...] On GitHub, `bundler/bundler` is archived, [...]
```

## Significant changes

- `https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md` (removed in https://github.com/rubygems/rubygems/pull/4980)
   - (in the context for asking an issue) `https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md`
   - (in the troubleshooting context) `https://bundler.io/doc/troubleshooting.html`

---

- Last part of #553

Closes #553

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)