### PR TITLE
Do not repeat .ruby-version in Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.2'
           bundler-cache: true # 'bundle install' and cache
 
       - name: Install Node.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.2'
           bundler-cache: true # 'bundle install' and cache
 
       - name: Install Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.2'
           bundler-cache: true
 
       - name: Run RuboCop


### PR DESCRIPTION
[`ruby/setup-ruby`](https://github.com/ruby/setup-ruby) can automatically detect the version required in Actions.

Closes #857

cf. https://github.com/ruby/setup-ruby/blob/3068fa83f9cbd7ae106cac45483635a2f3a195c9/README.md#supported-version-syntax

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)