### PR TITLE
Gemfile: use middleman/middleman from git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 ruby File.read(File.expand_path("../.ruby-version", __FILE__)).strip
 
 # Static site generator
-## See https://github.com/middleman/middleman/pull/2565
-gem "middleman", github: "tnir/middleman", branch: "delegate-each_with_index-sitemap-resourcelistcontainer"
+## Includes https://github.com/middleman/middleman/pull/2565, https://github.com/middleman/middleman/pull/2571
+gem "middleman", github: "middleman/middleman", ref: "038f4f606ff6cfc75cbe5c8690c5eae2e34f78f3"
 ## Extensions
 gem "middleman-blog"
 gem "middleman-search", github: "deivid-rodriguez/middleman-search", branch: "workarea-commerce-master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,9 @@ GIT
       nokogiri (~> 1.6)
 
 GIT
-  remote: https://github.com/tnir/middleman.git
-  revision: 80f9122a88c770a11726df4cd459c8b8acc7c166
-  branch: delegate-each_with_index-sitemap-resourcelistcontainer
+  remote: https://github.com/middleman/middleman.git
+  revision: 038f4f606ff6cfc75cbe5c8690c5eae2e34f78f3
+  ref: 038f4f606ff6cfc75cbe5c8690c5eae2e34f78f3
   specs:
     middleman (5.0.0.rc.2)
       coffee-script (~> 2.4)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that tnir's branch has been merged to the middleman/middleman repo, and it's perhaps more legible to refer to that repository.

- The desired Pull Request has been merged.
- I added a comment about a HAML 6-supporting change, as well. Perhaps we can begin using HAML 6, soon. https://haml.info/docs/yardoc/file.CHANGELOG.html looks meaty, that release. 1.7x quicker. Oh, perhaps https://github.com/rubygems/bundler-site/pull/918 is fixed, by this change.

### What was your diagnosis of the problem?

My diagnosis was that it would be easier to understand if we referred to the middleman/middleman repo instead of tnir's, now that the PR is merged.

### What is your fix for the problem, implemented in this PR?

My fix is to use the source repo, not the forked one, in our Gemfile.

### Why did you choose this fix out of the possible options?

N/A.