### PR TITLE
Make buttons easier to read

### DIFF
--- a/assets/stylesheets/_bootstrap-class-overrides.scss
+++ b/assets/stylesheets/_bootstrap-class-overrides.scss
@@ -1,0 +1,12 @@
+// See this issue https://github.com/rubygems/bundler-site/issues/684
+// to understand why we use this colors.
+.btn-primary {
+  color: #FFF;
+  background-color: #0D7FA5;
+  border-color: #0D7FA5;
+
+  &:hover {
+    background-color: #0A6A8A;
+    border-color: #095F7B;
+  }
+}

--- a/assets/stylesheets/_bootstrap-variable-overrides.scss
+++ b/assets/stylesheets/_bootstrap-variable-overrides.scss
@@ -1,6 +1,6 @@
 // for .btn-primary. This color is applied to $link-color so tweak is followed.
 // - Discussion: https://github.com/rubygems/bundler-site/pull/644#issuecomment-1178722939
-$primary: #12AEE2;
+$primary: #0D7FA5;
 
 // navbar
 $navbar-padding-y: 0;
@@ -37,14 +37,3 @@ $link-color: #337ab7;
 $link-decoration: none;
 $link-hover-decoration: underline;
 // /Transition workaround
-
-// Bootstrap 5 would suggest `color:#000` for `.btn-primary`/`.btn-primary:hover`
-// by default when `$primary: #12AEE2;` as it violates "WCAG 2.1 text color
-// contrast ratio of 4.5:1" if it is `color: #fff`.
-// https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=12AEE2 (2.56:1) (.btn-primary)
-// https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=0F94C0 (3.48:1) (.btn-primary:hover)
-//
-// Upstream change: https://github.com/twbs/bootstrap/pull/30168
-//
-// cf. https://stackoverflow.com/questions/65170317/sass-scss-bootstrap-5-color-functions-not-working-well
-$min-contrast-ratio: 2.55;

--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -23,7 +23,7 @@ pre {
 $pre-color: #fff;
 
 @import "code.css";
-@import "bootstrap-overrides";
+@import "bootstrap-variable-overrides";
 
 $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 
@@ -55,6 +55,8 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 
 // Utilities
 @import "~bootstrap/scss/utilities/api";
+
+@import "bootstrap-class-overrides";
 // end of Boostrap 5 customization
 
 @import "navbar";


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Closes #684

### What is your fix for the problem, implemented in this PR?

I changed the `.btn-primary` colors to `#0D7FA5` and `#0A6A8A`, this colors provide a contrast ration of [4.56:1](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=0D7FA5) and [6.1:1](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=0A6A8A), respectively.

I also renamed the file `_bootstrap-overrides.scss` to `_bootstrap-variable-overrides.scss`, and created the file `_bootstrap-class-overrides.scss`, this modifications is just to improve the code organization.

### Screenshots
**Before**
![master](https://user-images.githubusercontent.com/57065994/206864658-9d1ba111-edfd-4430-8a2b-b470e1f15969.png)
**After**
![white_text_fix](https://user-images.githubusercontent.com/57065994/206864665-ad3e1b25-392f-4147-8242-ed9f20e91a8a.png)
**Original colors with black text (just for comparison)**
![black_text_fix](https://user-images.githubusercontent.com/57065994/206864703-bb7a3ff7-8868-4eb0-8ad2-a747653fbbaf.png)

_*The first button has the hover effect active._

### Why did you choose this fix out of the possible options?

I chose this fix because it was already discussed before.
