### PR TITLE
Add `faraday-retry` gem to shush warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "kramdown"
 # Rake tasks
 gem "rake"
 ## To retrieve a list of contributors from GitHub
+gem "faraday-retry", "~> 2.0"
 gem "octokit", "~> 6.0"
 ## To generate ERB files from ronn files from rubygems/rubygems
 gem "ronn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     fastimage (2.2.6)
     ffi (1.15.5)
     haml (5.2.2)
@@ -203,6 +205,7 @@ PLATFORMS
 
 DEPENDENCIES
   builder
+  faraday-retry (~> 2.0)
   haml (~> 5.2.2)
   haml_lint (~> 0.43)
   kramdown


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when using octokit to retrieve contributors to the site from GitHub, we get the following warning:

> To use retry middleware with Faraday v2.0+, install `faraday-retry` gem

### What was your diagnosis of the problem?

My diagnosis was that this warning has bad UX because it seems impossible to get rid of it if you don't need retries.

### What is your fix for the problem, implemented in this PR?

My fix to add the `faraday-retry` gem, since it seems fine to have retries.

### Why did you choose this fix out of the possible options?

I chose this fix because warnings are annoying.
