### PR TITLE
Fix double load warnings

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -217,15 +217,6 @@ ymds.map { |ymd| ymd.sub(%r{/\d+/\d+$}, "") }.each do |y|
   redirect "blog/#{y}/index.html", to: "/blog/"
 end
 
-###
-# Helpers
-###
-Dir.glob(File.expand_path("../helpers/**/*.rb", __FILE__), &method(:require))
-helpers CommandReferenceHelper
-helpers ConfigHelper
-helpers DocsHelper
-helpers AvatarHelper
-
 activate :blog do |blog|
   blog.name = "blog"
   blog.prefix = "blog"

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -1,5 +1,7 @@
 module DocsHelper
-  ADDITIONAL_PAGES = %w(bundle.1 gemfile.5).freeze
+  def additional_pages
+    %w(bundle.1 gemfile.5).freeze
+  end
 
   def documentation_path(page, version=nil)
     check_single_page("/man/#{page}.html", version) || check_single_page("/#{page}.html", version) ||
@@ -51,7 +53,7 @@ module DocsHelper
     current_man_pages = sitemap.resources.select{ |page| page.path.start_with?("#{version}/man/bundle-") }
     commands_from_man = current_man_pages.map{ |page| strip_man_path_to_page(page.path) } # ex: bundle-config.1
 
-    (commands_from_man - primary_commands + ADDITIONAL_PAGES).sort do |x,y|
+    (commands_from_man - primary_commands + additional_pages).sort do |x,y|
       normalize_man_page(x) <=> normalize_man_page(y)
     end
   end

--- a/helpers/guides_helper.rb
+++ b/helpers/guides_helper.rb
@@ -1,13 +1,18 @@
 module GuidesHelper
-  LOCALIZABLE_REGEX = /localizable\/(.*)\.(.{2})\.html/
-  ADDITIONAL_GUIDES = %w(./source/doc/contributing/issues.html.md)
+  def localizable_regex
+    /localizable\/(.*)\.(.{2})\.html/
+  end
+
+  def additional_guides
+     %w(./source/doc/contributing/issues.html.md)
+  end
 
   def guides
     target_version = current_visible_version > "v1.15" ? "" : "#{current_visible_version}/"
     guides = Dir.glob("./source/#{target_version}guides/*")
     target_version = current_visible_version > "v1.15" ? "" : "v1.15/"
     localizable_guides = Dir.glob("./source/localizable/#{target_version}guides/*.en.html.md")
-    all_guides = guides + localizable_guides + ADDITIONAL_GUIDES
+    all_guides = guides + localizable_guides + additional_guides
 
     guides = all_guides.map do |filename|
       filename = filename.sub(/^\.\/source\//, "").sub(/\.(md|haml)$/, "")
@@ -26,7 +31,7 @@ module GuidesHelper
 
   def current_guide?(filename)
     return "active" if current_page.path == filename
-    matched = filename.match(LOCALIZABLE_REGEX)
+    matched = filename.match(localizable_regex)
     return "" unless matched
     return "active" if current_page.path == "#{matched[1]}.html"
     ""
@@ -35,7 +40,7 @@ module GuidesHelper
   private
 
   def process_localizable(filename)
-    matched = filename.match(LOCALIZABLE_REGEX)
+    matched = filename.match(localizable_regex)
     return "/#{filename}" unless matched
 
     "/#{matched[1]}.html"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when running `bin/rake versions:create`, a few warnings are printed:

```
/Users/deivid/Code/rubygems/bundler-site/helpers/docs_helper.rb:2: warning: already initialized constant DocsHelper::ADDITIONAL_PAGES
/Users/deivid/Code/rubygems/bundler-site/helpers/docs_helper.rb:2: warning: previous definition of ADDITIONAL_PAGES was here
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:2: warning: already initialized constant GuidesHelper::LOCALIZABLE_REGEX
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:2: warning: previous definition of LOCALIZABLE_REGEX was here
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:3: warning: already initialized constant GuidesHelper::ADDITIONAL_GUIDES
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:3: warning: previous definition of ADDITIONAL_GUIDES was here
/Users/deivid/Code/rubygems/bundler-site/helpers/docs_helper.rb:2: warning: already initialized constant DocsHelper::ADDITIONAL_PAGES
/Users/deivid/Code/rubygems/bundler-site/helpers/docs_helper.rb:2: warning: previous definition of ADDITIONAL_PAGES was here
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:2: warning: already initialized constant GuidesHelper::LOCALIZABLE_REGEX
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:2: warning: previous definition of LOCALIZABLE_REGEX was here
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:3: warning: already initialized constant GuidesHelper::ADDITIONAL_GUIDES
/Users/deivid/Code/rubygems/bundler-site/helpers/guides_helper.rb:3: warning: previous definition of ADDITIONAL_GUIDES was here
      create  source/blog/2022-12-22-bundler-v2-4.html.markdown
```

### What was your diagnosis of the problem?

My diagnosis was that these helpers are supposed to be automatically reloaded when changed, and that results in these double load errors since they are required using `Kernel.load`.

### What is your fix for the problem, implemented in this PR?

Not ideal, but using methods instead of constants gets rid of the warnings.

### Why did you choose this fix out of the possible options?

I chose this fix because it was easy and gets rid of the annoying warnings.
