### PR TITLE
Fix some haml-lint offenses

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -21,18 +21,6 @@ linters:
     ignored_cops:
       - "Style/StringLiterals"
 
-  SpaceBeforeScript:
-    exclude:
-      - "source/v1.13/whats_new.html.haml"
-      - "source/v1.14/whats_new.html.haml"
-      - "source/v1.15/whats_new.html.haml"
-      - "source/v1.16/whats_new.html.haml"
-      - "source/v1.17/whats_new.html.haml"
-      - "source/v2.0/whats_new.html.haml"
-      - "source/v2.1/whats_new.html.haml"
-      - "source/v2.2/whats_new.html.haml"
-      - "source/v2.3/whats_new.html.haml"
-
   SpaceInsideHashAttributes:
     exclude:
       - "source/contributors.html.haml"
@@ -49,15 +37,6 @@ linters:
   UnnecessaryStringOutput:
     exclude:
       - "source/layouts/base.haml"
-      - "source/v1.13/whats_new.html.haml"
-      - "source/v1.14/whats_new.html.haml"
-      - "source/v1.15/whats_new.html.haml"
-      - "source/v1.16/whats_new.html.haml"
-      - "source/v1.17/whats_new.html.haml"
-      - "source/v2.0/whats_new.html.haml"
-      - "source/v2.1/whats_new.html.haml"
-      - "source/v2.2/whats_new.html.haml"
-      - "source/v2.3/whats_new.html.haml"
 
   ViewLength:
     max: 413

--- a/lib/templates/whats_new.html.haml.erb
+++ b/lib/templates/whats_new.html.haml.erb
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler <%= version %> announcement', '/blog/<%= date_slug %>/bundler-v<%= version_slug %>.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/rubygems/blob/<%= rubygems_version %>/bundler/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/rubygems/blob/<%= rubygems_version %>/bundler/CHANGELOG.md"}.
 
   %h3 BIG NEW THING
   .contents

--- a/source/v1.13/whats_new.html.haml
+++ b/source/v1.13/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 1.13 announcement', '/blog/2016/09/08/bundler-1-13.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-13-stable/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-13-stable/CHANGELOG.md"}.
 
   %h3 New <code>doctor</code> command
   .contents
@@ -15,7 +15,7 @@
       .description
         %p
           Add the <code>doctor</code> command for automated troubleshooting. So far, it can automatically detect gems that have been compiled against libraries that no longer exist, and compile them again to fix them.
-          == (Thanks #{link_to '@mistydemeo', 'https://github.com/mistydemeo'}!)
+          (Thanks #{link_to '@mistydemeo', 'https://github.com/mistydemeo'}!)
 
   %h3 Support for <code>required_ruby_version</code>
   .contents

--- a/source/v1.14/whats_new.html.haml
+++ b/source/v1.14/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 1.14 announcement', '/blog/2017/03/28/bundler-1-14-so-many-fixes.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-14-stable/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-14-stable/CHANGELOG.md"}.
 
   %h3 Conservative updates
   .contents

--- a/source/v1.15/whats_new.html.haml
+++ b/source/v1.15/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 1.15 announcement', '/blog/2017/05/19/bundler-1-15-bundle-oh-so-fast.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-15-stable/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-15-stable/CHANGELOG.md"}.
 
   %h3 Exec optimization
   .contents

--- a/source/v1.16/whats_new.html.haml
+++ b/source/v1.16/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 1.16 announcement', '/blog/2017/10/31/bundler-1-16.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-16-stable/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-16-stable/CHANGELOG.md"}.
 
   %h3 Resolver improvements
   .contents

--- a/source/v1.17/whats_new.html.haml
+++ b/source/v1.17/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 1.17 announcement', '/blog/2018/10/25/announcing-bundler-1-17-0.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-17-stable/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/1-17-stable/CHANGELOG.md"}.
 
   %h3 Remove gems from the CLI
   .contents

--- a/source/v2.0/whats_new.html.haml
+++ b/source/v2.0/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 2.0 announcement', '/blog/2019/01/03/announcing-bundler-2.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/2-0-stable/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/2-0-stable/CHANGELOG.md"}.
 
   %h3 Breaking changes
   .contents

--- a/source/v2.1/whats_new.html.haml
+++ b/source/v2.1/whats_new.html.haml
@@ -6,7 +6,7 @@
   %p
     This time there was not blog post announcement for the 2.1 release, but as
     always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/2-1-stable/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/bundler/blob/2-1-stable/CHANGELOG.md"}.
 
   %p
     The main change in bundler 2.1 is that deprecations for upcoming breaking

--- a/source/v2.2/whats_new.html.haml
+++ b/source/v2.2/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 2.2 announcement', '/blog/2020/12/09/bundler-v2-2.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/rubygems/blob/3.2/bundler/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/rubygems/blob/3.2/bundler/CHANGELOG.md"}.
 
   %h3 Multiplatform support
   .contents

--- a/source/v2.3/whats_new.html.haml
+++ b/source/v2.3/whats_new.html.haml
@@ -7,7 +7,7 @@
     The
     = link_to 'Bundler 2.3 announcement', '/blog/2022/01/23/bundler-v2-3.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
-    == #{link_to "the changelog", "https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md"}.
+    #{link_to "the changelog", "https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md"}.
 
   %h3 Bundler Version Locking
   .contents


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when adding a new minor version to the documentation site, we need to remember to add exclusions to haml-lint configuration or else haml-lint will fail.

### What was your diagnosis of the problem?

My diagnosis was that we can fix the haml-lint offenses, to get cleaner templates and also not have to remember to add new exclusions when we add new versions.

### What is your fix for the problem, implemented in this PR?

My fix is to fix the offenses and the template.

### Why did you choose this fix out of the possible options?

I chose this fix because just adding new exclusions was inferior in terms of maintainability.
