### PR TITLE
Fix octokit getting rate-limited in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,4 @@ jobs:
         run: bundle exec rake build
         env:
           NO_CONTRACTS: "true"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/tasks/contributors.rake
+++ b/lib/tasks/contributors.rake
@@ -18,7 +18,9 @@ namespace :contributors do
 
     require "octokit"
     require "yaml"
-    client = Octokit::Client.new(auto_paginate: true)
+    options = { auto_paginate: true }
+    options[:access_token] = ENV["GITHUB_TOKEN"] if ENV["GITHUB_TOKEN"]
+    client = Octokit::Client.new(**options)
     contributors = client.contributors("rubygems/rubygems", false)
     contributors.reject!{|c| credited_elsewhere.include?(c[:login]) }
     contributors.map! do |c|


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that sometimes CI can fail due to API calls to the GitHub API getting rate-limited.

### What was your diagnosis of the problem?

My diagnosis was, thanks to the helpful error message, that we should be doing authenticated calls.

### What is your fix for the problem, implemented in this PR?

My fix is to use the `GITHUB_TOKEN` available in CI to authenticate the API calls.
