### PR TITLE
Update compatible versions of Ruby/RubyGems with Bundler 2.4

### DIFF
--- a/source/compatibility.html.haml
+++ b/source/compatibility.html.haml
@@ -12,10 +12,16 @@ description: Ruby and RubyGems requirements needed for Bundler compatibility
 .contents
   .bullet
     .description
-      Bundler <b>2</b>
+      Bundler <b>2.4</b> or higher
     .notes
       %ul
-        %li Requires a minimum Ruby version of <b>2.3.0</b>.
+        %li requires a minimum ruby version of <b>2.6.0</b>.
+
+    .description
+      Bundler <b>2.0</b> through <b>2.3</b>
+    .notes
+      %ul
+        %li requires a minimum ruby version of <b>2.3.0</b>.
 
     .description
       Bundler <b>1</b>
@@ -34,7 +40,13 @@ description: Ruby and RubyGems requirements needed for Bundler compatibility
 .contents
   .bullet
     .description
-      Bundler <b>2</b>
+      Bundler <b>2.4</b> or higher
+    .notes
+      %ul
+        %li Requires a minimum RubyGems version of <b>3.0.1</b>.
+
+    .description
+      Bundler <b>2.0</b> through <b>2.3</b>
     .notes
       %ul
         %li Requires a minimum RubyGems version of <b>2.5</b>, since that's the version of RubyGems included with Ruby <b>2.3.0</b>.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

https://bundler.io/compatibility.html is now mis-leading since Bundler 2.4.0 was just released: https://rubygems.org/gems/bundler/versions/2.4.0

### What was your diagnosis of the problem?

Bundler 2.4 requires both Ruby 2.6 or higher and RubyGems 3.0.1 or higher (https://github.com/rubygems/rubygems/pull/6107).

### What is your fix for the problem, implemented in this PR?

Adds entries for Bundler 2.4 or higher and fixes the existing entries for Bundler 2 with Bundler 2.0-2.3.

### Why did you choose this fix out of the possible options?

No other option is not considerable.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>