### PR TITLE
Use Bundler 2.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,4 +225,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.3.26
+   2.4.1


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`bundler-site` is still using Bundler 2.3.x.

### What was your diagnosis of the problem?

This site should use Bundler 2.4 (latest).

### What is your fix for the problem, implemented in this PR?

Use Bundler 2.4.1 on build.

### Why did you choose this fix out of the possible options?

n/a

## Ref.

- https://github.com/rubygems/rubygems/pull/6191

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)