### PR TITLE
Fix rate limit when building site for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,10 @@ jobs:
         id: pages
         uses: actions/configure-pages@v2
 
-      - run: bundle exec rake build # Output to ./_site as build_dir is configured in config.rb
+      - name: Build site
+        run: bundle exec rake build # Output to ./_site as build_dir is configured in config.rb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: echo "bundler.io" > ./build/CNAME
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the deployment task can fail due to GitHub API rate limiting due to the same issue as #980.

### What was your diagnosis of the problem?

My diagnosis was the we should also use authenticated API calls when deploying.

### What is your fix for the problem, implemented in this PR?

My fix is to apply the same solution as #980.
