### PR TITLE
Migrate from `ronn` to `ronn-ng`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "rake"
 gem "faraday-retry", "~> 2.0"
 gem "octokit", "~> 6.0"
 ## To generate ERB files from ronn files from rubygems/rubygems
-gem "ronn"
+gem "ronn-ng", github: "apjanke/ronn-ng"
 ## To strip (man:strip_pages)
 gem "nokogiri", "~> 1.13"
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "rake"
 gem "faraday-retry", "~> 2.0"
 gem "octokit", "~> 6.0"
 ## To generate ERB files from ronn files from rubygems/rubygems
-gem "ronn-ng", github: "apjanke/ronn-ng"
+gem "ronn-ng", github: "deivid-rodriguez/ronn-ng", branch: "fix-charset"
 ## To strip (man:strip_pages)
 gem "nokogiri", "~> 1.13"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/apjanke/ronn-ng.git
-  revision: 5c3da4065a4d3c42d80b3751cf5350a8c42bdc32
-  specs:
-    ronn-ng (0.10.1.pre1)
-      kramdown (~> 2.1)
-      kramdown-parser-gfm (~> 1.0.1)
-      mustache (~> 1.0)
-      nokogiri (~> 1.11, >= 1.11.0)
-
-GIT
   remote: https://github.com/deivid-rodriguez/middleman-search.git
   revision: 50465e1c1580e282a45247b77036da3c2719870d
   branch: workarea-commerce-master
@@ -17,6 +7,17 @@ GIT
       middleman-core (>= 3.2)
       mini_racer (~> 0.5)
       nokogiri (~> 1.6)
+
+GIT
+  remote: https://github.com/deivid-rodriguez/ronn-ng.git
+  revision: f1c1c79414c85351720e1d9ff6cd1737fe337295
+  branch: fix-charset
+  specs:
+    ronn-ng (0.10.1.pre1)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0.1)
+      mustache (~> 1.0)
+      nokogiri (~> 1.11, >= 1.11.0)
 
 GIT
   remote: https://github.com/middleman/middleman.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/apjanke/ronn-ng.git
+  revision: 5c3da4065a4d3c42d80b3751cf5350a8c42bdc32
+  specs:
+    ronn-ng (0.10.1.pre1)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0.1)
+      mustache (~> 1.0)
+      nokogiri (~> 1.11, >= 1.11.0)
+
+GIT
   remote: https://github.com/deivid-rodriguez/middleman-search.git
   revision: 50465e1c1580e282a45247b77036da3c2719870d
   branch: workarea-commerce-master
@@ -91,12 +101,13 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashie (5.0.0)
-    hpricot (0.8.6)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     kramdown (2.4.0)
       rexml
+    kramdown-parser-gfm (1.0.1)
+      kramdown (~> 2.0)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-arm64-darwin)
     libv8-node (16.10.0.0-x86_64-linux)
@@ -152,17 +163,12 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdiscount (2.2.0.2)
     regexp_parser (2.6.1)
     rexml (3.2.5)
     rgl (0.5.9)
       pairing_heap (>= 0.3.0)
       rexml (~> 3.2, >= 3.2.4)
       stream (~> 0.5.3)
-    ronn (0.7.3)
-      hpricot (>= 0.8.2)
-      mustache (>= 0.7.0)
-      rdiscount (>= 1.5.8)
     rouge (3.30.0)
     rubocop (1.41.1)
       json (~> 2.3)
@@ -218,7 +224,7 @@ DEPENDENCIES
   pry
   pry-byebug
   rake
-  ronn
+  ronn-ng!
   rubocop
 
 RUBY VERSION


### PR DESCRIPTION


### What was the end-user problem that led to this PR?

The problem was that the Ronn gem and its dependencies have been abandoned for 10 years. It has worked pretty well so far but we're seeing some unstability now. In particular, we've seen some C-level crashes inside the hpricot dependency.

### What was your diagnosis of the problem?

My diagnosis was that we should migrate to newer alternatives.

### What is your fix for the problem, implemented in this PR?

My fix is to migrate to the currently maintained fork, [ronn-ng](https://github.com/apjanke/ronn-ng). I also needed to pick up [one fix](https://github.com/n-ronn/nronn/commit/09be8af91dcb01693848a9884d66a011235ce6ac) by @tnir.

I will propose this fix to ronn-ng and ask whether they would allow us to get commit and release access there.

### Why did you choose this fix out of the possible options?

I chose this fix because creating [yet another fork](https://github.com/n-ronn/nronn) as in #841 seems worse for the community so we could try the existing fork first.
