### PR TITLE
Add Bundler 2.4 to documentation

### DIFF
--- a/helpers/config_helper.rb
+++ b/helpers/config_helper.rb
@@ -14,9 +14,9 @@ module ConfigHelper
   private
 
   def status(version)
-    if version == "v2.3"
+    if version == "v2.4"
       "Current release"
-    elsif %w[v2.2 v2.1].include?(version)
+    elsif %w[v2.3 v2.2 v2.1].include?(version)
       "Legacy release"
     else
       "Deprecated release"

--- a/source/v2.4/docs.html.haml
+++ b/source/v2.4/docs.html.haml
@@ -1,0 +1,36 @@
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle-help.1)
+
+.bg-light-blue.header
+  = image_tag '/images/docs_header_transparent_bg.png',
+    srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
+    class: 'img-fluid header-padding',
+    style: 'max-width: 400px;'
+
+.container
+  .row.docs.my-5
+    .col-md-6.col-12
+      %h3
+        %b Guides
+      %p
+        Step-by-step tutorials that include useful explanations and and detailed instructions to help you get up and running.
+      %ul.ul-padding
+        - guides.each do |guide|
+          %li= link_to_guide guide
+        %li= link_to "Contributing to Bundler", "/doc/readme.html"
+
+    .col-md-5.offset-md-1.col-12
+      %h3
+        %b Reference Guides
+      %p
+        In-depth articles with information on each primary command and utility, and how to use them.
+      %h4
+        %b Primary Commands
+      %ul.ul-padding
+        - primary_commands.select{ |page| path_exist?(page) }.each do |page|
+          %li= link_to_documentation(page)
+
+      %h4
+        %b Utilities
+      %ul.ul-padding
+        - other_commands(primary_commands).each do |page|
+          %li= link_to_documentation(page)

--- a/source/v2.4/whats_new.html.haml
+++ b/source/v2.4/whats_new.html.haml
@@ -1,0 +1,8 @@
+.container.guide
+  %h1
+    What's New in
+    = current_visible_version
+
+  %p
+    As always, a detailed list of every change is provided in
+    #{link_to "the changelog", "https://github.com/rubygems/rubygems/blob/3.4/bundler/CHANGELOG.md"}.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I want to hold just a bit on publish the blog post, but that shouldn't block publishing documentation pages for Bundler 2.4.

### What was your diagnosis of the problem?

My diagnosis was that we should extract documentation from #978.

### What is your fix for the problem, implemented in this PR?

My fix extract documentation to this PR. Include a bare "What's new page" with just a link to the changelog for now.

### Why did you choose this fix out of the possible options?

I chose this fix because it unblocks @tnir :)
