### PR TITLE
Stop making plain text pages available at the top level

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -48,8 +48,8 @@ activate :external_pipeline,
 
 # Make documentation for the latest version available at the top level, too.
 # Any pages with names that conflict with files already at the top level will be skipped.
-Dir.glob("./source/#{config[:current_version]}/**/*").select{ |f| File.file?(f) }.each do |file_path|
-  file_path = file_path.sub(/(\.haml$|\.md$)/, "")
+Dir.glob("./source/#{config[:current_version]}/*.haml").each do |file_path|
+  file_path = file_path.sub(/\.haml$/, "")
 
   page_path = file_path.sub(/^\.\/source\//, "")
   proxy_path = file_path["./source/#{config[:current_version]}/".length..-1]
@@ -179,7 +179,6 @@ page "/conduct.html", layout: :two_column_layout
 page "/compatibility.html", layout: :two_column_layout
 page /\/v(\d+.\d+)\/(?!bundle_|commands|docs|man)(.*)/, layout: :two_column_layout
 page /\/v(.*)\/man\/(.*)/, layout: :two_column_layout
-page /\/man\/(.*)/, layout: false
 page /\/v(.*)\/guides\/(.*)/, layout: :two_column_layout
 page /guides\/(.*)/, layout: :two_column_layout
 page /\/doc\/(.*)/, layout: :two_column_layout # Imported from rubygems/bundler

--- a/lib/tasks/man_generator/man.rake
+++ b/lib/tasks/man_generator/man.rake
@@ -29,8 +29,4 @@ task man: :update_vendor do
       Rake::Task["man:strip_pages"].execute("#{segments_up}/source/#{version}/man")
     end
   end
-
-  # Make man pages for the latest version available at the top level, too.
-  rm_rf "source/man"
-  cp_r "source/#{VERSIONS.last}/man", "source"
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was some pages render as plain text.

Link for "Edit this document on GitHub" is broken in top-level `/man/` pages (#930).

### What was your diagnosis of the problem?

My diagnosis was that we should get rid of 

```ruby
page /\/man\/(.*)/, layout: false
```

from our config, since that's what's rendering content without a layout.

### What is your fix for the problem, implemented in this PR?

My fix is to remove that line and fix the issues that come up after doing that.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes #992 without regressing #930.
