### PR TITLE
Redirect to the latest man page when version isn't specified

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -165,6 +165,14 @@ end
   redirect "v#{version}/guides/bundler_2_upgrade.html", to: "guides/bundler_2_upgrade.html"
 end
 
+# Redirect to the latest man page when version isn't specified
+man_files = Dir.glob("./source/#{config[:current_version]}/man/*.html.erb")
+man_files.each do |file|
+  url = file.delete_prefix("./source/#{config[:current_version]}/").delete_suffix(".erb")
+  latest_man = "#{config[:current_version]}/#{url}"
+  redirect url, to: latest_man
+end
+
 redirect "sponsors.html", to: "https://rubygems.org/pages/sponsors" # Backwards compatibility
 
 page "/conduct.html", layout: :two_column_layout


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`https://bundler.io/man/bundle-init.1.html` is now dead again.

### What was your diagnosis of the problem?

That is due to merging both #990 and #993.

### What is your fix for the problem, implemented in this PR?

Some parts originally prepared in #965 by @gustavothecoder should be re-introduced.

Closes #992

### Why did you choose this fix out of the possible options?

No other options are considerable.