### PR TITLE
Update internal links to versioned guides with the latest ones

### DIFF
--- a/source/blog/2018-06-07-may-bundler-update.html.markdown
+++ b/source/blog/2018-06-07-may-bundler-update.html.markdown
@@ -8,7 +8,7 @@ author_url: http://www.stephaniemorillo.co
 
 Welcome to the May Bundler update!
 
-Last month, Bundler saw some bug fixes, [a new `--skip-install` flag](https://github.com/rubygems/bundler/commit/9e87a1ca4b0c3002ac2774e4837234cef7e3ce08) for `bundler add`, and a [new guide on writing Bundler plugins](https://bundler.io/v1.16/guides/bundler_plugins.html). (Thank you [@jules2689](https://github.com/jules2689) for producing this guide!)
+Last month, Bundler saw some bug fixes, [a new `--skip-install` flag](https://github.com/rubygems/bundler/commit/9e87a1ca4b0c3002ac2774e4837234cef7e3ce08) for `bundler add`, and a [new guide on writing Bundler plugins](https://bundler.io/guides/bundler_plugins.html). (Thank you [@jules2689](https://github.com/jules2689) for producing this guide!)
 
 Bundler gained 9 new commits, contributed by 3 authors. There were 66 additions and 48 deletions across 17 files.
 

--- a/source/blog/2018-09-10-august-bundler-update.html.markdown
+++ b/source/blog/2018-09-10-august-bundler-update.html.markdown
@@ -7,7 +7,7 @@ author_url: http://www.stephaniemorillo.co
 
 Welcome to the August monthly update!
 
-With the help of [@eanlain](http://github.com/eanlain), we shipped a new guide: [“How to use Bundler with Docker”](https://bundler.io/v1.16/guides/bundler_docker_guide.html). We also dramatically improved error messages when version requirements conflict, shipped a playbook for adding or removing core team members, and fixed some issues handling gemspecs with non-ASCII characters. We also merged a fix that could cause Bundler to [fail when trying to install a gem that has had a version yanked recently](https://github.com/rubygems/bundler/pull/6675).
+With the help of [@eanlain](http://github.com/eanlain), we shipped a new guide: [“How to use Bundler with Docker”](https://bundler.io/guides/bundler_docker_guide.html). We also dramatically improved error messages when version requirements conflict, shipped a playbook for adding or removing core team members, and fixed some issues handling gemspecs with non-ASCII characters. We also merged a fix that could cause Bundler to [fail when trying to install a gem that has had a version yanked recently](https://github.com/rubygems/bundler/pull/6675).
 
 On top of that code work, we also added two new contributors to [the Bundler team](https://bundler.io/contributors.html)! Welcome to [Stephanie Morillo](https://www.twitter.com/radiomorillo) and [Grey Baker](https://twitter.com/greybaker).
 

--- a/source/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -445,4 +445,4 @@ Please include:
 ### Contributing to this guide
 [contributing-to-guide]: #contributing-to-this-guide
 
-If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/rubygems/bundler-site/blob/master/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!
+If you found a solution not listed here, submit a PR to add your solution to [this guide](https://github.com/rubygems/bundler-site/blob/master/source/guides/rubygems_tls_ssl_troubleshooting_guide.html.md)!


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Some links in the site are still linking to `/:version/guides/:slug.md`, which should be now correctly redirected to `/guides/:slug.md`.

### What was your diagnosis of the problem?

#651 avoided to update links in the contents.

Follows up #651.

### What is your fix for the problem, implemented in this PR?

Replace `/:version/guides/` wth `/guides/` in files under`/source`.

### Why did you choose this fix out of the possible options?

Makes it easier for maintainers to update links in the future.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
