### PR TITLE
Update activesupport from 7.0.3.1 to 7.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`activesupport` used in this repo is not up-to-date.

### What was your diagnosis of the problem?

https://github.com/rails/rails/blob/v7.0.4/activesupport/CHANGELOG.md

### What is your fix for the problem, implemented in this PR?

Updates activesupport gem from 7.0.3.1 to 7.0.4.

### Why did you choose this fix out of the possible options?

To make the following changes minimal.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)