### PR TITLE
Use https instead of http for links to slack.bundler.io

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -15,7 +15,7 @@
     = link_to t('home.what_can_bundler_do'), "/guides/getting_started.html#getting-started", class: 'btn btn-primary btn-lg'
     = link_to "#{t("home.new_in")} #{current_version}", '/whats_new.html', class: 'btn btn-primary btn-lg'
     = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
-    = link_to t('home.chat_with_us'), 'http://slack.bundler.io', class: 'btn btn-primary btn-lg'
+    = link_to t('home.chat_with_us'), 'https://slack.bundler.io', class: 'btn btn-primary btn-lg'
 
 .bg-light-blue
   .container
@@ -60,7 +60,7 @@
       %h2#get-involved Get involved
       .my-4.large-font
         Bundler has a lot of contributors and users, and we would love to have your help!
-        If you have questions, join #{link_to 'the Bundler Slack', 'http://slack.bundler.io'}
+        If you have questions, join #{link_to 'the Bundler Slack', 'https://slack.bundler.io'}
         and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with
         #{link_to 'the contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md'}.
         While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'}
@@ -69,6 +69,6 @@
 
       .d-grid.d-md-flex.gap-2.mx-auto.my-md-4.justify-content-md-center
         = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary btn-lg'
-        = link_to 'Join the Bundler Slack', 'http://slack.bundler.io', class: 'btn btn-primary btn-lg'
+        = link_to 'Join the Bundler Slack', 'https://slack.bundler.io', class: 'btn btn-primary btn-lg'
         = link_to 'Contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary btn-lg'
         = link_to 'Report security issue', 'https://hackerone.com/rubygems', class: 'btn btn-primary btn-lg'


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

All links to `slack.bundler.io` have been `http`-protocol based for a long time.

### What was your diagnosis of the problem?

In late 2010s, we should use `https`. It is (almost) 2023.

### What is your fix for the problem, implemented in this PR?

Forces to use https against `slack.bundler.io`.

### Why did you choose this fix out of the possible options?

https://www.ssllabs.com/ssltest/analyze.html?d=slack.bundler.io&latest supports this change as well.

In this PR, the PR author does not care about why so many links on the top page 😭 

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
