### PR TITLE
Update middleman-search to edge to use Ruby 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby File.read(File.expand_path("../.ruby-version", __FILE__)).strip
 gem "middleman", github: "middleman/middleman", ref: "038f4f606ff6cfc75cbe5c8690c5eae2e34f78f3"
 ## Extensions
 gem "middleman-blog"
-gem "middleman-search", github: "deivid-rodriguez/middleman-search", branch: "workarea-commerce-master"
+gem "middleman-search", github: "tnir/middleman-search", branch: "edge" # https://github.com/manastech/middleman-search/pull/39
 gem "middleman-syntax"
 
 ## Template engines

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/deivid-rodriguez/middleman-search.git
-  revision: 50465e1c1580e282a45247b77036da3c2719870d
-  branch: workarea-commerce-master
-  specs:
-    middleman-search (0.10.0)
-      middleman-core (>= 3.2)
-      mini_racer (~> 0.5)
-      nokogiri (~> 1.6)
-
-GIT
   remote: https://github.com/deivid-rodriguez/ronn-ng.git
   revision: f1c1c79414c85351720e1d9ff6cd1737fe337295
   branch: fix-charset
@@ -58,6 +48,16 @@ GIT
       tilt (~> 2.0.9)
       toml
       webrick
+
+GIT
+  remote: https://github.com/tnir/middleman-search.git
+  revision: 45af9e686469142fb003f58d6cd0ae0ba33cb496
+  branch: edge
+  specs:
+    middleman-search (0.10.0)
+      middleman-core (>= 3.2)
+      mini_racer (~> 0.5)
+      nokogiri (~> 1.6)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Current version of middleman-search does not support Ruby 3.2 as its syntax is too legacy.

### What was your diagnosis of the problem?

Ruby 3.2-ready code is available at https://github.com/manastech/middleman-search/pull/39 or https://github.com/tnir/middleman-search/tree/edge.

### What is your fix for the problem, implemented in this PR?

Makes the code ready to use Ruby 3.2.

### Why did you choose this fix out of the possible options?

Once https://github.com/manastech/middleman-search/pull/39 is merged, we can use the upstream.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
