### PR TITLE
Use the absolute link in guides/bundler_workflow

### DIFF
--- a/source/guides/bundler_workflow.html.md
+++ b/source/guides/bundler_workflow.html.md
@@ -216,4 +216,4 @@ $ bin/rspec spec/models
 The executables installed into `bin` are scoped to the
 bundle, and will always work.
 
-<a href="./man/bundle-exec.1.html" class="btn btn-primary">Learn More: Executables</a>
+<a href="/man/bundle-exec.1.html" class="btn btn-primary">Learn More: Executables</a>


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A link in https://bundler.io/guides/bundler_workflow.html is dead.

### What was your diagnosis of the problem?

Following up #651 is missing 😢 .

### What is your fix for the problem, implemented in this PR?

Use the absolute link instead.

### Why did you choose this fix out of the possible options?

Leaving deadlinks should be harmful.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)