### PR TITLE
HAML-Lint: cleanup UnnecessaryStringOutput

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -34,9 +34,5 @@ linters:
     exclude:
       - "source/contributors.html.haml"
 
-  UnnecessaryStringOutput:
-    exclude:
-      - "source/layouts/base.haml"
-
   ViewLength:
     max: 413

--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -8,7 +8,7 @@
     %meta{ name: "globalsign-domain-verification", content: "276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL" }
     %title
       - page_title = current_page.data.title
-      = "Bundler: #{ page_title || "The best way to manage a Ruby application's gems" }"
+      Bundler: #{ page_title || "The best way to manage a Ruby application's gems" }
 
     = yield_content :head
 


### PR DESCRIPTION
- Follows up #776

To minimize .haml-lint.yml and to clean up HAML code.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)