### PR TITLE
Update kramdown-parser-gfm from 1.0.1 to 1.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     json (2.6.3)
     kramdown (2.4.0)
       rexml
-    kramdown-parser-gfm (1.0.1)
+    kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-arm64-darwin)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

We still use kramdown-parser-gfm 1.0.1, which was released in 2019 (4 years ago).

🎉 https://github.com/kramdown/parser-gfm/blob/master/CHANGELOG.md#110--2019-05-29

### What was your diagnosis of the problem?

Simply we can use the latest published version of [kramdown-parser-gfm](https://rubygems.org/gems/kramdown-parser-gfm).

### What is your fix for the problem, implemented in this PR?

Forces to use kramdown-parser-gfm 1.1.0 instead of 1.0.1

### Why did you choose this fix out of the possible options?

But 1.1.0 was released in 3.5+ years ago.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)