### PR TITLE
Update rack from 2.2.4 to 2.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.0)
     racc (1.6.1)
-    rack (2.2.4)
+    rack (2.2.5)
     rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.2)


### PR DESCRIPTION
See https://github.com/rack/rack/pull/1998 for Ruby 3.2.0

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

### What was the end-user problem that led to this PR?

Nothing. But we will encounter some problem described in https://github.com/rack/rack/pull/1998 for Ruby 3.2.0 since we are already in 3.2.0 #984.

### What was your diagnosis of the problem?

We cannot use rack 3.0 since middleman blocks it.

### What is your fix for the problem, implemented in this PR?

Updates rack from 2.2.4 to 2.2.5.

### Why did you choose this fix out of the possible options?

Maybe we can allow middleman to use rack 3.0 if we have time to contribute middleman.