### PR TITLE
Update oj from 3.13.21 to 3.13.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oj (3.13.21)
+    oj (3.13.23)
     padrino-helpers (0.15.1)
       i18n (>= 0.6.7, < 2)
       padrino-support (= 0.15.1)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`oj`, which was dependent from `middleman-core` is not up-to-date.

### What was your diagnosis of the problem?

https://github.com/ohler55/oj/blob/v3.13.23/CHANGELOG.md

### What is your fix for the problem, implemented in this PR?

Just updates oj from 3.13.21 to 3.13.22.

### Why did you choose this fix out of the possible options?

I hope to have indirect updates (note that https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow shows `indirect` is not supported for `rubygems`)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
