### PR TITLE
Update racc from 1.6.1 to 1.6.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.0)
-    racc (1.6.1)
+    racc (1.6.2)
     rack (2.2.5)
     rainbow (3.1.1)
     rake (13.0.6)


### PR DESCRIPTION
Release note of rack 1.6.2 missed the largest change: https://github.com/ruby/racc/commit/9b0a22c999c3c55ec2aca585468d456d1eca2378

- https://github.com/ruby/racc/releases/tag/v1.6.2
- https://github.com/ruby/racc/compare/v1.6.1...v1.6.2

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)