### PR TITLE
Update public_suffix from 5.0.0 to 5.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (5.0.0)
+    public_suffix (5.0.1)
     racc (1.6.2)
     rack (2.2.5)
     rainbow (3.1.1)


### PR DESCRIPTION
https://github.com/weppos/publicsuffix-ruby/compare/v5.0.0...v5.0.1

Nothing special.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)