### PR TITLE
Fix redirect comment

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -114,7 +114,7 @@ end
     redirect "v#{version}/#{filename}.html", to: "v1.15/guides/#{filename}.html"
   end
 
-  # Redirect versioned-guides (which are not localizable) on v1.15 and below to version-independent guides
+  # Redirect versioned-guides (which are not localizable) on v1.12-v1.14 to version-independent guides
   %w[bundler_setup sinatra].each do |filename|
     redirect "v#{version}/#{filename}.html", to: "guides/#{filename}.html"
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This comment claims that `https://bundler.io/v1.15/bundler_setup.html` redirects to `https://bundler.io/guides/bundler_setup.html`, but that's not true. 

### What is your fix for the problem, implemented in this PR?
  
Fix the comment to describe reality.