### PR TITLE
Update bundler from 2.4.1 to 2.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,4 +230,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.4.1
+   2.4.2


### PR DESCRIPTION
https://github.com/rubygems/rubygems/releases/tag/bundler-v2.4.2

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)