### PR TITLE
Update terser from 1.1.12 to 1.1.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     stream (0.5.5)
     sysexits (1.2.0)
     temple (0.9.1)
-    terser (1.1.12)
+    terser (1.1.13)
       execjs (>= 0.3.0, < 3)
     thor (1.2.1)
     tilt (2.0.11)


### PR DESCRIPTION
https://my.diffend.io/gems/terser/1.1.12/1.1.13

While we are already on 5.16.1 😬 #1020

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)