### PR TITLE
Remove exceptions for IdNames linter from .haml-lint.yml

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,13 +1,6 @@
 skip_frontmatter: true
 
 linters:
-  IdNames:
-    exclude:
-      - "source/guides/bundler_plugins.html.haml"
-      - "source/guides/bundler_workflow.html.haml"
-      - "source/guides/rails.html.haml"
-      - "source/v1.15/guides/rails.html.haml"
-
   InlineStyles:
     exclude:
       - "source/contributors.html.haml"


### PR DESCRIPTION
As #1045, #1006, #1046, and #1027 removed all files with exceptions, now we can remove these exceptions for `IdNames` linter from `.haml-lint.yml`.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)