### PR TITLE
Add current_version to whats_new link

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -13,7 +13,7 @@
 
   .d-grid.d-md-flex.gap-2.mx-auto.my-md-4.justify-content-md-center
     = link_to t('home.what_can_bundler_do'), "/guides/getting_started.html#getting-started", class: 'btn btn-primary btn-lg'
-    = link_to "#{t("home.new_in")} #{current_version}", '/whats_new.html', class: 'btn btn-primary btn-lg'
+    = link_to "#{t("home.new_in")} #{current_version}", "/#{current_version}/whats_new.html", class: 'btn btn-primary btn-lg'
     = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
     = link_to t('home.chat_with_us'), 'https://slack.bundler.io', class: 'btn btn-primary btn-lg'
 


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?
- It seems that  page link of "New in v2.4"  button on https://bundler.io/  is incorrect because the link missing version path
  - I can see the page with https://bundler.io/v2.4/whats_new.html 

### What was your diagnosis of the problem?
- Missing version in the  `whats_new.html ` page link

### What is your fix for the problem, implemented in this PR?
- Fix the link to contain version like `https://bundler.io/v2.4/whats_new.html `

### Why did you choose this fix out of the possible options?
- Because I found these links that contain version
  - https://bundler.io/v2.2/whats_new.html
  - https://bundler.io/v2.3/whats_new.html
  - https://bundler.io/v2.4/whats_new.html
