### PR TITLE
You do not have to reuqire rubygems on Ruby 1.9+

### DIFF
--- a/source/guides/bundler_setup.html.md
+++ b/source/guides/bundler_setup.html.md
@@ -7,7 +7,6 @@ Configure the load path so all dependencies in
 your Gemfile can be required
 
 ~~~ruby
-require 'rubygems'
 require 'bundler/setup'
 require 'nokogiri'
 ~~~
@@ -17,7 +16,6 @@ load path. If you want the gems in the
 default group, make sure to include it
 
 ~~~ruby
-require 'rubygems'
 require 'bundler'
 Bundler.setup(:default, :ci)
 require 'nokogiri'
@@ -43,14 +41,12 @@ application loads (for Sinatra, the file that calls `require 'sinatra'`), put
 the following code:
 
 ~~~ruby
-require 'rubygems'
 require 'bundler/setup'
 ~~~
 
 This will automatically discover your `Gemfile` and make all of the gems in
 your `Gemfile` available to Ruby (in technical terms, it puts the gems "on the
-load path"). You can think of it as adding some extra powers to `require
-'rubygems'`.
+load path").
 
 Now that your code is available to Ruby, you can require the gems that you need. For
 instance, you can `require 'sinatra'`. If you have a lot of dependencies, you

--- a/source/guides/bundler_workflow.html.md
+++ b/source/guides/bundler_workflow.html.md
@@ -183,7 +183,6 @@ $ bundle update
 Inside your app, load up the bundled environment:
 
 ~~~ruby
-require 'rubygems'
 require 'bundler/setup'
 
 # require your gems as usual

--- a/source/guides/getting_started.html.md
+++ b/source/guides/getting_started.html.md
@@ -48,7 +48,6 @@ the same third-party code that you are using now.
 Inside your app, load up the bundled environment:
 
 ~~~ruby
-require 'rubygems'
 require 'bundler/setup'
 
 # require your gems as usual

--- a/source/guides/groups.html.md
+++ b/source/guides/groups.html.md
@@ -68,7 +68,6 @@ control the groups that are loaded by
 and `BUNDLE_WITHOUT` configurations.
 
 ~~~ruby
-require 'rubygems'
 require 'bundler'
 Bundler.setup(:default, :ci)
 require 'nokogiri'

--- a/source/guides/rationale.html.md
+++ b/source/guides/rationale.html.md
@@ -96,7 +96,6 @@ application loads (for Sinatra, the file that calls `require 'sinatra'`), put
 the following code:
 
 ~~~ruby
-require 'rubygems'
 require 'bundler/setup'
 ~~~
 

--- a/source/guides/sinatra.html.md
+++ b/source/guides/sinatra.html.md
@@ -13,7 +13,6 @@ gem 'sinatra'
 Then, set up your config.ru file to load the bundle before it loads your Sinatra app.
 
 ~~~ruby
-require 'rubygems'
 require 'bundler'
 
 Bundler.require

--- a/source/localizable/guides/bundler_setup.es.html.md
+++ b/source/localizable/guides/bundler_setup.es.html.md
@@ -7,7 +7,6 @@ Configure la ruta de carga para que todas las dependencias en
 su Gemfile puedan ser requerídas
 
 ~~~ruby
-require 'rubygems'
 require 'bundler/setup'
 require 'nokogiri'
 ~~~
@@ -17,7 +16,6 @@ a la ruta de carga. Si quiere usar las gemas en el grupo
 por defecto, inclúyalo
 
 ~~~ruby
-require 'rubygems'
 require 'bundler'
 Bundler.setup(:default, :ci)
 require 'nokogiri'
@@ -43,14 +41,12 @@ que su aplicación carga (para Sinatra, el archivo que contiene `require 'sinatr
 ponga el código siguiente:
 
 ~~~ruby
-require 'rubygems'
 require 'bundler/setup'
 ~~~
 
 Esto automáticamente lee su `Gemfile`, y hace que todas
 las gemas en él estén disponibles para Ruby (en terminos
-técnicos, pone las gemas en "la ruta de carga"). Puede pensarlo
-como una manera de agregar superpoderes extra a `require 'rubygems'`.
+técnicos, pone las gemas en "la ruta de carga").
 
 Ahora que su código está disponible para Ruby, puede requerir
 las gemas que necesite. Por ejemplo, puede usar el código `require 'sinatra'`.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`require 'rubygems'` lines still exist in the docs.

### What was your diagnosis of the problem?

We do not need `require 'rubygems'` any more.

### What is your fix for the problem, implemented in this PR?

Removes `require 'rubygems'`.

### Why did you choose this fix out of the possible options?

The document does not have to support Ruby 1.8 and earlier in 2023.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)