### PR TITLE
Update Slack invite link.

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -15,7 +15,7 @@
     = link_to t('home.what_can_bundler_do'), "/guides/getting_started.html#getting-started", class: 'btn btn-primary btn-lg'
     = link_to "#{t("home.new_in")} #{current_version}", "/#{current_version}/whats_new.html", class: 'btn btn-primary btn-lg'
     = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
-    = link_to t('home.chat_with_us'), 'https://slack.bundler.io', class: 'btn btn-primary btn-lg'
+    = link_to t('home.chat_with_us'), 'https://join.slack.com/t/bundler/shared_invite/zt-1rrsuuv3m-OmXKWQf8K6iSla4~F1DBjQ', class: 'btn btn-primary btn-lg'
 
 .bg-light-blue
   .container
@@ -60,7 +60,7 @@
       %h2#get-involved Get involved
       .my-4.large-font
         Bundler has a lot of contributors and users, and we would love to have your help!
-        If you have questions, join #{link_to 'the Bundler Slack', 'https://slack.bundler.io'}
+        If you have questions, join #{link_to 'the Bundler Slack', 'https://join.slack.com/t/bundler/shared_invite/zt-1rrsuuv3m-OmXKWQf8K6iSla4~F1DBjQ'}
         and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with
         #{link_to 'the contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md'}.
         While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'}
@@ -69,6 +69,6 @@
 
       .d-grid.d-md-flex.gap-2.mx-auto.my-md-4.justify-content-md-center
         = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary btn-lg'
-        = link_to 'Join the Bundler Slack', 'https://slack.bundler.io', class: 'btn btn-primary btn-lg'
+        = link_to 'Join the Bundler Slack', 'https://join.slack.com/t/bundler/shared_invite/zt-1rrsuuv3m-OmXKWQf8K6iSla4~F1DBjQ', class: 'btn btn-primary btn-lg'
         = link_to 'Contributing guide', 'https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md', class: 'btn btn-primary btn-lg'
         = link_to 'Report security issue', 'https://hackerone.com/rubygems', class: 'btn btn-primary btn-lg'


### PR DESCRIPTION
- this link is configured to never expired
- it seems to be limited to 400 uses, but better than nothing for now :pray: 