### PR TITLE
chore(deps): update bundler from 2.4.2 to 2.4.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,4 +239,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.2
+   2.4.12


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Nothing

### What was the developer problem that led to this PR?

The developer of this site would use the latest version of Bundler as of writing.

### What was your diagnosis of the problem?

https://rubygems.org/gems/bundler/versions/2.4.12 is the latest version of Bundler.


### What is your fix for the problem, implemented in this PR?

Update Bundler to 2.4.2 to 2.4.12 (latest).

### Why did you choose this fix out of the possible options?

Dogfooding might be better than nothing.