### PR TITLE
Clarify that Bundler comes preinstalled by default

### DIFF
--- a/source/guides/getting_started.html.md
+++ b/source/guides/getting_started.html.md
@@ -16,9 +16,9 @@ Starting work on a project is as simple as `bundle install`.
 ## Getting Started
 <a name="getting-started"></a>
 
-This guide assumes that you have both [Ruby](https://www.ruby-lang.org/en/downloads/)
-and [RubyGems](https://rubygems.org/pages/download) installed. If you do not have Ruby
-and RubyGems installed, do that first and then check back here!
+This guide assumes that you have [Ruby](https://www.ruby-lang.org/en/downloads/)
+installed. If you do not have Ruby installed, do that first and then check back here!
+Any modern distribution of Ruby comes with Bundler preinstalled by default.
 
 Getting started with bundler is easy!
 Specify your dependencies in a Gemfile in your project's root:

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -35,7 +35,13 @@
     .large-font.mt-4
       .bullet
         .description
+          %p
+            This guide assumes that you have #{link_to 'Ruby', 'https://www.ruby-lang.org/en/downloads/'}
+            installed. If you do not have Ruby installed, do that first and then check back here!
+            Any modern distribution of Ruby comes with Bundler preinstalled by default.
+
           %p= t('home.getting_started_description')
+
         :code
           # lang: ruby
           source 'https://rubygems.org'


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that it was not clear that you don't really need to install Bundler if you have Ruby installed.

### What is your fix for the problem, implemented in this PR?

My fix is to make it explicit that Ruby comes with Bundler by default.