### PR TITLE
chore(deps): update Node.js to 16.x to 18.x on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
- Follows up PR #1156

### What was the end-user problem that led to this PR?

n/a

### What was the developer problem that led to this PR?

They will not want to use Node.js 16, which will be EOL'd very soon.

### What was your diagnosis of the problem?

CI can use Node.js 18, which is the current active LTS.

### What is your fix for the problem, implemented in this PR?

Node.js 18 is used instead of 16 even on CI.

### Why did you choose this fix out of the possible options?

Node.js 16 will be EOL'd in 2-3 months.