### PR TITLE
Fix grammar (subject-verb agreement) in git.html.md

### DIFF
--- a/source/guides/git.html.md
+++ b/source/guides/git.html.md
@@ -164,7 +164,7 @@ gem 'rack', github: 'rack/rack', branch: 'master'
 
 Now instead of checking out the remote git repository, the local
 override will be used. Similar to a path source, every time the local
-git repository change, changes will be automatically picked up by
+git repository changes, the changes will be automatically picked up by
 Bundler. This means a commit in the local git repo will update the
 revision in the `Gemfile.lock` to the local git repo revision. This
 requires the same attention as git submodules. Before pushing to


### PR DESCRIPTION
<!--
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user problem that led to this PR?

I just noticed a small grammar error in the documentation.

### What was your diagnosis of the problem?

Subject-verb agreement was incorrect: "... every time the local git repository change, ..."

### What is your fix for the problem, implemented in this PR?

Change the phrase to read "... every time the local git repository changes, the changes will be automatically picked up by Bundler."

### Why did you choose this fix out of the possible options?

I chose this fix because...
It's a straightforward fix that corrects the grammar and makes it sound correct to native English readers without changing the meaning.
