### PR TITLE
Skip two Bundler plugins known to be outdated

### DIFF
--- a/data/known_plugins.yml
+++ b/data/known_plugins.yml
@@ -28,12 +28,6 @@
 - :name: bundler-ecology
   :summary: Bundler plugin to avoid installing unwanted gems
   :uri: https://github.com/eco-rb/bundler-ecology
-- :name: bundler-explain
-  :summary: Explains bundle update conflicts
-  :uri: https://github.com/jhawthorn/bundler-explain
-- :name: bundler-fast_git
-  :summary: Make bundler git source faster
-  :uri: https://github.com/mtsmfm/bundler-fast_git
 - :name: bundler-graph
   :summary: Generates a visual dependency graph for your Gemfile
   :uri: https://github.com/rubygems/bundler-graph

--- a/lib/tasks/regenerate_known_plugins_yml.rake
+++ b/lib/tasks/regenerate_known_plugins_yml.rake
@@ -13,6 +13,8 @@ task :regenerate_known_plugins_yml do
     bundler-interactive source-does-not-exist yanked-all-but-last
     bundler-next
     bundler-security
+    bundler-explain
+    bundler-fast_git
   ]
 
   rubygems = Gem::Source.new("https://rubygems.org")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that two plugins were seen which ought to have been skipped.

Their functionality's now built-in.

### What was your diagnosis of the problem?

My diagnosis was that the skip list was not updated.

### What is your fix for the problem, implemented in this PR?

My fix was to extend the skip list with two more gems.

Also, I ran the Rake task, to get the result seen in data/.

### Why did you choose this fix out of the possible options?

I chose this fix because I got a good hint.

Fixes #1231