### PR TITLE
Skip bundler-shellsplit-plugin

### DIFF
--- a/data/known_plugins.yml
+++ b/data/known_plugins.yml
@@ -57,10 +57,6 @@
   :summary: A Bundler plugin that installs gems in an additional private Gemfile after
     bundle install.
   :uri: https://github.com/fphilipe/bundler-private_install
-- :name: bundler-shellsplit-plugin
-  :summary: Plugin to fix shell splitting of bundle config arguments in Bundler 1.17.3
-    to Bundler 2.0.2, fixed in Bundler 2.1.0.
-  :uri: https://github.com/wovnio/bundler-shellsplit-plugin
 - :name: bundler-source-aws-s3
   :summary: Add aws-s3 source to bundler via plugin.
   :uri: https://github.com/eki/bundler-source-aws-s3

--- a/lib/tasks/regenerate_known_plugins_yml.rake
+++ b/lib/tasks/regenerate_known_plugins_yml.rake
@@ -10,11 +10,12 @@ task :regenerate_known_plugins_yml do
     extended_bundler-errors
   ]
   skipped_gems = %w[
+    bundler-explain
+    bundler-fast_git
     bundler-interactive source-does-not-exist yanked-all-but-last
     bundler-next
     bundler-security
-    bundler-explain
-    bundler-fast_git
+    bundler-shellsplit-plugin
   ]
 
   rubygems = Gem::Source.new("https://rubygems.org")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Its source does not exist, and its summary explicitly says the problem has been fixed in Bundler 2.1.0

### What was your diagnosis of the problem?

The gem should not be listed.

### What is your fix for the problem, implemented in this PR?

Skip it.

### Why did you choose this fix out of the possible options?

Precedent of skipping other outdated plugins.