### PR TITLE
Add CHANGELOG as vendored file

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,7 +7,7 @@ config[:current_version] = config[:versions].last
 activate :syntax
 activate :i18n
 activate :search do |search|
-  search.resources = ["index.html", "guides/", "#{config[:current_version]}/", "compatibility.html", "conduct.html", "contributors.html"]
+  search.resources = ["index.html", "guides/", "#{config[:current_version]}/", "changelog.html", "compatibility.html", "conduct.html", "contributors.html"]
 
   search.index_path = "search/lunr-index.json"
 
@@ -187,6 +187,7 @@ end
 
 redirect "sponsors.html", to: "https://rubygems.org/pages/sponsors" # Backwards compatibility
 
+page "/changelog.html", layout: :two_column_layout
 page "/conduct.html", layout: :two_column_layout
 page "/compatibility.html", layout: :two_column_layout
 page /\/v(\d+.\d+)\/(?!bundle_|commands|docs|man)(.*)/, layout: :two_column_layout

--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -14,6 +14,8 @@ RELATIVE_LINK_REGEX = %r{
 def new_link(file, link)
   if link.end_with?("CODE_OF_CONDUCT.md")
     "conduct" # Special case we manually write
+  elsif link.end_with?("CHANGELOG.md")
+    "changelog" # Special case we manually write
   elsif link.start_with?("mailto:") || link.start_with?("http")
     link
   else
@@ -65,5 +67,6 @@ task repo_pages: :update_vendor do
     end
 
     write_file("../CODE_OF_CONDUCT.md", File.expand_path("./conduct.html.md", source_dir))
+    write_file("../CHANGELOG.md", File.expand_path("./changelog.html.md", source_dir))
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that a link to the CHANGELOG was 404ing. So, (in a now-closed PR) I made the link absolute, instead of relative, to work around the problem.

But, that'd take us to another website to look at Bundler's CHANGELOG. It'd be nice if Bundler's website knew about the CHANGELOG - had it locally.

### What was your diagnosis of the problem?

My diagnosis was we didn't have all files that would be necessary to create a local CHANGELOG, we'd have to point outside this repo, to some on-GitHub data, not very nice. Not rendered in this nice way.

### What is your fix for the problem, implemented in this PR?

Include CHANGELOG as a file in the generated site.

This fixes #1233.
This fixes #846 

### Why did you choose this fix out of the possible options?

I chose this fix because we mentioned it in #1233.
