### PR TITLE
Back to nronn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "rake"
 gem "faraday-retry", "~> 2.2"
 gem "octokit", "~> 8.0"
 ## To generate ERB files from ronn files from rubygems/rubygems
-gem "ronn-ng", github: "apjanke/ronn-ng"
+gem "nronn"
 ## To strip (man:strip_pages)
 gem "nokogiri", "~> 1.15"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/apjanke/ronn-ng.git
-  revision: 44db815d89d641b52e7fa5ae7df9951d5ed5b623
-  specs:
-    ronn-ng (0.10.1.pre3)
-      kramdown (~> 2.1)
-      kramdown-parser-gfm (>= 1.0.1, < 1.2)
-      mustache (~> 1.1)
-      nokogiri (~> 1.10, >= 1.10.10)
-
-GIT
   remote: https://github.com/middleman/middleman.git
   revision: 50f76c2984c4f82b243b0a5e3f860aeaf63e07d5
   ref: 50f76c2984c4f82b243b0a5e3f860aeaf63e07d5
@@ -142,6 +132,11 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
+    nronn (0.11.1)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (>= 1.0.1, < 1.2)
+      mustache (~> 1.0)
+      nokogiri (~> 1.10, >= 1.10.10)
     octokit (8.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -239,10 +234,10 @@ DEPENDENCIES
   middleman-search!
   middleman-syntax
   nokogiri (~> 1.15)
+  nronn
   octokit (~> 8.0)
   pry-byebug
   rake
-  ronn-ng!
   rubocop
   rubocop-rake
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Using the fork released to rubygems.org is what @tnir did initially at https://github.com/rubygems/bundler-site/pull/841, but I reverted that at https://github.com/rubygems/bundler-site/pull/1021 because:

* I wasn't sure if it was intentionally permanent or just to unlock deployments.
* I wanted to be ronn-ng one last chance.

* ### What was your diagnosis of the problem?

My diagnosis was that ronn-ng has not really got any traction and I decided to move on to nronn in Bundler at https://github.com/rubygems/rubygems/pull/7227.

### What is your fix for the problem, implemented in this PR?

My fix is to also migrate to nronn here.

### Why did you choose this fix out of the possible options?

I chose this fix because it sounds like the best path going forward.
