### PR TITLE
rel: add Bundler 2.5 as the latest version to docs

### DIFF
--- a/helpers/config_helper.rb
+++ b/helpers/config_helper.rb
@@ -14,9 +14,9 @@ module ConfigHelper
   private
 
   def status(version)
-    if version == "v2.4"
+    if version == "v2.5"
       "Current release"
-    elsif %w[v2.3 v2.2 v2.1].include?(version)
+    elsif %w[v2.4 v2.3 v2.2].include?(version)
       "Legacy release"
     else
       "Deprecated release"

--- a/source/v2.5/docs.html.haml
+++ b/source/v2.5/docs.html.haml
@@ -1,0 +1,36 @@
+- primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle-help.1)
+
+.bg-light-blue.header
+  = image_tag '/images/docs_header_transparent_bg.png',
+              srcset: '/images/docs_header_transparent_bg.png 1x, /images/docs_header_transparent_bg@2x.png 2x, /images/docs_header_transparent_bg@3x.png 3x',
+              class: 'img-fluid header-padding',
+              style: 'max-width: 400px;'
+
+.container
+  .row.docs.my-5
+    .col-md-6.col-12
+      %h3
+        %b Guides
+      %p
+        Step-by-step tutorials that include useful explanations and and detailed instructions to help you get up and running.
+      %ul.ul-padding
+        - guides.each do |guide|
+          %li= link_to_guide guide
+        %li= link_to "Contributing to Bundler", "/doc/readme.html"
+
+    .col-md-5.offset-md-1.col-12
+      %h3
+        %b Reference Guides
+      %p
+        In-depth articles with information on each primary command and utility, and how to use them.
+      %h4
+        %b Primary Commands
+      %ul.ul-padding
+        - primary_commands.select{ |page| path_exist?(page) }.each do |page|
+          %li= link_to_documentation(page)
+
+      %h4
+        %b Utilities
+      %ul.ul-padding
+        - other_commands(primary_commands).each do |page|
+          %li= link_to_documentation(page)

--- a/source/v2.5/whats_new.html.md
+++ b/source/v2.5/whats_new.html.md
@@ -1,0 +1,11 @@
+# What's New in v2.5
+
+As always, a detailed list of every change is provided in
+[the changelog](https://github.com/rubygems/rubygems/blob/3.5/bundler/CHANGELOG.md).
+
+## Breaking changes
+
+- Drop ruby 2.6 and 2.7 support [#7116](https://github.com/rubygems/rubygems/pull/7116)
+- The `:mswin`, `:mswin64`, `:mingw`, and `:x64_mingw` Gemfile `platform` values are soft-deprecated and aliased to `:windows` [#6391](https://github.com/rubygems/rubygems/pull/6391)
+
+<a href="https://github.com/rubygems/rubygems/blob/3.5/bundler/CHANGELOG.md" class="btn btn-primary">Full 2.5 changelog</a>


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Bundler 2.5.0 was successfully released on 2023-12-15, and it is still hard for end-users to find Bundler 2.1 to be fully deprecated.

- https://rubygems.org/gems/bundler/versions/2.5.0

### What was your diagnosis of the problem?

- The latest should be Bundler 2.5.

### What is your fix for the problem, implemented in this PR?

- This publishes Bundler 2.5 as the latest version.
- This also marks Bundler 2.1 as legacy.

![bundler-2 5](https://github.com/rubygems/bundler-site/assets/10229505/1397cef7-185a-4fff-829e-e3205969c5a7)

### Why did you choose this fix out of the possible options?

No other possible options.

### Refs.

- Previous update (bundler 2.4): #991