### PR TITLE
rails setup: add missing newline from markdown

### DIFF
--- a/source/guides/rails.html.md
+++ b/source/guides/rails.html.md
@@ -16,6 +16,7 @@ $ gem install rails
 We recommend using rvm for dependable Ruby
 installations, especially if you are switching
 between different versions of Ruby
+
 Generate a Rails app as usual
 
 ~~~


### PR DESCRIPTION
A missing newline causes the instructions for two different parts to merge, adding it back make things clearer.
