### PR TITLE
Document `file` option for `ruby` directive

### DIFF
--- a/source/guides/gemfile_ruby.html.md
+++ b/source/guides/gemfile_ruby.html.md
@@ -21,6 +21,18 @@ It's also possible to restrict the patchlevel of the Ruby used by doing the foll
 ruby '1.9.3', :patchlevel => '448'
 ~~~
 
+If you wish to derive your Ruby version from a version file (i.e. `.ruby-version`),
+you can use the `file` option instead.
+
+~~~ruby
+ruby file: ".ruby-version"
+~~~
+
+The version file should conform to any of the following formats:
+
+- `3.1.2` (`.ruby-version`)
+- `ruby 3.1.2` ([`.tool-versions`](https://asdf-vm.com/manage/configuration.html#tool-versions))
+
 Bundler will make checks against the current running Ruby VM to make sure it matches what is specified in the `Gemfile`. If things don't match, Bundler will raise an Exception explaining what doesn't match.
 
 ~~~


### PR DESCRIPTION
Feature was implemented in https://github.com/rubygems/rubygems/pull/6876 and documented on the
[manpage](https://bundler.io/v2.5/man/gemfile.5.html#VERSION-required-)
but it seems like it makes sense to have on [this page](https://bundler.io/guides/gemfile_ruby.html) as well, as it is the top google result for "gemfile ruby version".

This copy is lifted (and lightly edited) from the manpage source https://github.com/rubygems/rubygems/blob/6bbc8bed344eeaadcbd8dfcc6e20c9e1eb734d96/bundler/lib/bundler/man/gemfile.5.ronn?plain=1#L72-L80
