### PR TITLE
Update a compatibility page for Bundler 2.5

### DIFF
--- a/source/compatibility.html.haml
+++ b/source/compatibility.html.haml
@@ -21,7 +21,13 @@ description: Ruby and RubyGems requirements needed for Bundler compatibility
 .contents
   .bullet
     .description
-      Bundler <b>2.4</b> or higher
+      Bundler <b>2.5</b> or higher
+    .notes
+      %ul
+        %li requires a minimum ruby version of <b>3.0.0</b>, and a minimum RubyGems version of <b>3.2.3</b> (version of RubyGems shipped with ruby <b>3.0.0</b>).
+
+    .description
+      Bundler <b>2.4</b>
     .notes
       %ul
         %li requires a minimum ruby version of <b>2.6.0</b>, and a minimum RubyGems version of <b>3.0.1</b> (version of RubyGems shipped with ruby <b>2.6.0</b>).


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the end-user who uses Ruby 2.6-3.0 cannot find the installable bundler version on the compatibility page.

### What is your fix for the problem, implemented in this PR?

Add a description that Bundler 2.5 requires Ruby 3.0.0 and RubyGems 3.2.3.