### PR TITLE
Set hreflang

### DIFF
--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -12,6 +12,10 @@
 
     = yield_content :head
 
+    - site_url = %w[es pl].include?(I18n.locale) ? "https://bundler.io/#{I18n.locale}/" : "https://bundler.io/"
+
+    %link{ rel: 'alternate', href: site_url, hreflang: I18n.locale }
+
     - if content_for?(:canonical)
       %link{ rel: "canonical", href: yield_content(:canonical) }
 


### PR DESCRIPTION
Apparently this is what Google considers to show localized versions with otherwise duplicate content.


### What was the end-user problem that led to this PR?

The `bundler.cn` site shows up in search results when looking for `bundle check` in Google.

### What was your diagnosis of the problem?

According to https://moz.com/learn/seo/hreflang-tag, Google uses hreflang and not language metatags like the ones were are setting:

> Note that while Google and Yandex currently use the hreflang attribute, Bing uses [language meta tags](http://blogs.bing.com/webmaster/2011/03/01/how-to-tell-bing-your-websites-country-and-language/) instead.

### What is your fix for the problem, implemented in this PR?

My fix is to try set hreflang to see if it helps with #1333.

### Why did you choose this fix out of the possible options?

I chose this fix because I guess it may help and shouldn't do any bad?
