### PR TITLE
Fix typo --add-checkums → --add-checksums

### DIFF
--- a/source/blog/2024-12-19-bundler-v2-6.html.markdown
+++ b/source/blog/2024-12-19-bundler-v2-6.html.markdown
@@ -32,7 +32,7 @@ consider it compromised.
 
 Bundler 2.6 provides two ways of enabling checksums.
 
-* For a single lockfile, you can run `bundle lock --add-checkums`. This will add
+* For a single lockfile, you can run `bundle lock --add-checksums`. This will add
   a new `CHECKSUMS` section to the lockfile that Bundler will keep up to date.
 
 * To configure Bundler to always include checksums in new lockfiles, run `bundle


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A typo in the recent blog post https://bundler.io/blog/2024/12/19/bundler-v2-6.html made it harder than necessary to try out the new `--add-checksums` feature.

### What was your diagnosis of the problem?

My diagnosis was: it’s a typo.