### PR TITLE
Fix redirects including URL fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ source/conduct.html.md
 source/doc
 
 # man pages built from the bundler repo
-/source/man/
 /source/v*/man/
 
 # deploy key

--- a/config.rb
+++ b/config.rb
@@ -177,14 +177,6 @@ end
   redirect "v#{version}/guides/bundler_2_upgrade.html", to: "guides/bundler_2_upgrade.html"
 end
 
-# Redirect to the latest man page when version isn't specified
-man_files = Dir.glob("./source/#{config[:current_version]}/man/*.html.erb")
-man_files.each do |file|
-  url = file.delete_prefix("./source/#{config[:current_version]}/").delete_suffix(".erb")
-  latest_man = "#{config[:current_version]}/#{url}"
-  redirect url, to: latest_man
-end
-
 redirect "sponsors.html", to: "https://rubygems.org/pages/sponsors" # Backwards compatibility
 
 page "/changelog.html", layout: :two_column_layout
@@ -192,6 +184,7 @@ page "/conduct.html", layout: :two_column_layout
 page "/compatibility.html", layout: :two_column_layout
 page /\/v(\d+.\d+)\/(?!bundle_|commands|docs|man)(.*)/, layout: :two_column_layout
 page /\/v(.*)\/man\/(.*)/, layout: :two_column_layout
+page /man\/(.*)/, layout: :two_column_layout
 page /\/v(.*)\/guides\/(.*)/, layout: :two_column_layout
 page /guides\/(.*)/, layout: :two_column_layout
 page /\/doc\/(.*)/, layout: :two_column_layout # Imported from rubygems/bundler

--- a/data/contributors.yml
+++ b/data/contributors.yml
@@ -23,14 +23,14 @@
   :commits: 303
   :href: https://github.com/bronzdoc
   :name: bronzdoc
-- :avatar_url: https://avatars.githubusercontent.com/u/193936?v=4&s=40
-  :commits: 285
-  :href: https://github.com/simi
-  :name: simi
 - :avatar_url: https://avatars.githubusercontent.com/in/29110?v=4&s=40
-  :commits: 283
+  :commits: 290
   :href: https://github.com/apps/dependabot
   :name: dependabot[bot]
+- :avatar_url: https://avatars.githubusercontent.com/u/193936?v=4&s=40
+  :commits: 287
+  :href: https://github.com/simi
+  :name: simi
 - :avatar_url: https://avatars.githubusercontent.com/u/237?v=4&s=40
   :commits: 278
   :href: https://github.com/chad
@@ -335,6 +335,10 @@
   :commits: 14
   :href: https://github.com/Shekharrajak
   :name: Shekharrajak
+- :avatar_url: https://avatars.githubusercontent.com/u/24788699?v=4&s=40
+  :commits: 14
+  :href: https://github.com/soda92
+  :name: soda92
 - :avatar_url: https://avatars.githubusercontent.com/u/174?v=4&s=40
   :commits: 14
   :href: https://github.com/wilson
@@ -415,10 +419,6 @@
   :commits: 11
   :href: https://github.com/ryanfox1985
   :name: ryanfox1985
-- :avatar_url: https://avatars.githubusercontent.com/u/24788699?v=4&s=40
-  :commits: 11
-  :href: https://github.com/soda92
-  :name: soda92
 - :avatar_url: https://avatars.githubusercontent.com/u/22021150?v=4&s=40
   :commits: 10
   :href: https://github.com/ankitkataria

--- a/lib/tasks/versions.rake
+++ b/lib/tasks/versions.rake
@@ -20,6 +20,12 @@ namespace :versions do
     render_whats_new(succ)
     puts "Creating announcement blog post..."
     sh "middleman article 'Bundler #{succ}'"
+    puts "Updating latest version symlinks..."
+    Dir.glob("source/#{succ}/man/*.html.erb") do |file|
+      url = file.delete_prefix("source/#{succ}/")
+      latest_man = "source/#{url}"
+      FileUtils.ln_sf Pathname.new(file).relative_path_from(File.dirname(latest_man)), latest_man
+    end
   end
 end
 

--- a/source/changelog.html.md
+++ b/source/changelog.html.md
@@ -1,3 +1,27 @@
+# 3.6.2 / 2024-12-23
+
+## Security:
+
+* Fix Gem::SafeMarshal buffer overrun when given lengths larger than fit
+  into a byte. Pull request
+  [#8305](https://github.com/rubygems/rubygems/pull/8305) by segiddins
+* Improve type checking in marshal_load methods. Pull request
+  [#8306](https://github.com/rubygems/rubygems/pull/8306) by segiddins
+
+## Enhancements:
+
+* Skip rdoc hooks and their tests on newer rdoc versions. Pull request
+  [#8340](https://github.com/rubygems/rubygems/pull/8340) by
+  deivid-rodriguez
+* Installs bundler 2.6.2 as a default gem.
+
+## Bug fixes:
+
+* Fix serialized metadata including an empty `@original_platform`
+  attribute. Pull request
+  [#8355](https://github.com/rubygems/rubygems/pull/8355) by
+  deivid-rodriguez
+
 # 3.6.1 / 2024-12-17
 
 ## Enhancements:

--- a/source/layouts/two_column_layout.haml
+++ b/source/layouts/two_column_layout.haml
@@ -1,7 +1,7 @@
 - is_command = command?(current_page.url) || whats_new?(current_page.url)
 - v = current_page.url.scan(/v\d\.\d+/).first || current_version
 
-- if /v\d\.\d+\//.match?(current_page.destination_path)
+- if current_page.destination_path.start_with?(current_version)
   - content_for(:canonical, commands_toplevel_path(current_page.destination_path))
 
 ~ wrap_layout :base do

--- a/source/man/bundle-add.1.html.erb
+++ b/source/man/bundle-add.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-add.1.html.erb

--- a/source/man/bundle-binstubs.1.html.erb
+++ b/source/man/bundle-binstubs.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-binstubs.1.html.erb

--- a/source/man/bundle-cache.1.html.erb
+++ b/source/man/bundle-cache.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-cache.1.html.erb

--- a/source/man/bundle-check.1.html.erb
+++ b/source/man/bundle-check.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-check.1.html.erb

--- a/source/man/bundle-clean.1.html.erb
+++ b/source/man/bundle-clean.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-clean.1.html.erb

--- a/source/man/bundle-config.1.html.erb
+++ b/source/man/bundle-config.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-config.1.html.erb

--- a/source/man/bundle-console.1.html.erb
+++ b/source/man/bundle-console.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-console.1.html.erb

--- a/source/man/bundle-doctor.1.html.erb
+++ b/source/man/bundle-doctor.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-doctor.1.html.erb

--- a/source/man/bundle-env.1.html.erb
+++ b/source/man/bundle-env.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-env.1.html.erb

--- a/source/man/bundle-exec.1.html.erb
+++ b/source/man/bundle-exec.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-exec.1.html.erb

--- a/source/man/bundle-fund.1.html.erb
+++ b/source/man/bundle-fund.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-fund.1.html.erb

--- a/source/man/bundle-gem.1.html.erb
+++ b/source/man/bundle-gem.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-gem.1.html.erb

--- a/source/man/bundle-help.1.html.erb
+++ b/source/man/bundle-help.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-help.1.html.erb

--- a/source/man/bundle-info.1.html.erb
+++ b/source/man/bundle-info.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-info.1.html.erb

--- a/source/man/bundle-init.1.html.erb
+++ b/source/man/bundle-init.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-init.1.html.erb

--- a/source/man/bundle-inject.1.html.erb
+++ b/source/man/bundle-inject.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-inject.1.html.erb

--- a/source/man/bundle-install.1.html.erb
+++ b/source/man/bundle-install.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-install.1.html.erb

--- a/source/man/bundle-issue.1.html.erb
+++ b/source/man/bundle-issue.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-issue.1.html.erb

--- a/source/man/bundle-licenses.1.html.erb
+++ b/source/man/bundle-licenses.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-licenses.1.html.erb

--- a/source/man/bundle-list.1.html.erb
+++ b/source/man/bundle-list.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-list.1.html.erb

--- a/source/man/bundle-lock.1.html.erb
+++ b/source/man/bundle-lock.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-lock.1.html.erb

--- a/source/man/bundle-open.1.html.erb
+++ b/source/man/bundle-open.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-open.1.html.erb

--- a/source/man/bundle-outdated.1.html.erb
+++ b/source/man/bundle-outdated.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-outdated.1.html.erb

--- a/source/man/bundle-platform.1.html.erb
+++ b/source/man/bundle-platform.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-platform.1.html.erb

--- a/source/man/bundle-plugin.1.html.erb
+++ b/source/man/bundle-plugin.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-plugin.1.html.erb

--- a/source/man/bundle-pristine.1.html.erb
+++ b/source/man/bundle-pristine.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-pristine.1.html.erb

--- a/source/man/bundle-remove.1.html.erb
+++ b/source/man/bundle-remove.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-remove.1.html.erb

--- a/source/man/bundle-show.1.html.erb
+++ b/source/man/bundle-show.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-show.1.html.erb

--- a/source/man/bundle-update.1.html.erb
+++ b/source/man/bundle-update.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-update.1.html.erb

--- a/source/man/bundle-version.1.html.erb
+++ b/source/man/bundle-version.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-version.1.html.erb

--- a/source/man/bundle-viz.1.html.erb
+++ b/source/man/bundle-viz.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle-viz.1.html.erb

--- a/source/man/bundle.1.html.erb
+++ b/source/man/bundle.1.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/bundle.1.html.erb

--- a/source/man/gemfile.5.html.erb
+++ b/source/man/gemfile.5.html.erb
@@ -1,0 +1,1 @@
+../v2.6/man/gemfile.5.html.erb


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some pages include links to URLs with a fragment, and without a `v2.x/` url segment, and the fragment is actually lost when clicking the link. See for example the https://bundler.io/man/gemfile.5.html#PLATFORMS link in https://bundler.io/guides/using_bundler_in_applications.html#gemfilelock.

### What was your diagnosis of the problem?

My diagnosis was that middleman uses client side redirects to implement redirections, so pages like https://bundler.io/man/gemfile.5.html actually serve the following content, with a 200 status:

```
curl https://bundler.io/man/gemfile.5.html 
              <html>
                <head>
                  <link rel="canonical" href="/v2.6/man/gemfile.5.html" />
                  <meta http-equiv=refresh content="0; url=/v2.6/man/gemfile.5.html" />
                  <meta name="robots" content="noindex,follow" />
                  <meta http-equiv="cache-control" content="no-cache" />
                </head>
                <body>
                </body>
              </html>
```

That means requesting a client side redirect (without the fragment).

### What is your fix for the problem, implemented in this PR?

My fix is to actually serve the same content as `v2.6/man/gemfile.5.html`, by making everything in `v2.6/man/` a symlink to `man/`. We will serve duplicated content, but our canonical meta tags should hint crawlers about what the canonical page is.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes https://github.com/rubygems/bundler-site/issues/1347, and it may also help with SEO issues like https://github.com/rubygems/bundler-site/issues/1333.
