### PR TITLE
Add missing /whats_new.html page

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -182,6 +182,7 @@ redirect "sponsors.html", to: "https://rubygems.org/pages/sponsors" # Backwards 
 page "/changelog.html", layout: :two_column_layout
 page "/conduct.html", layout: :two_column_layout
 page "/compatibility.html", layout: :two_column_layout
+page "/whats_new.html", layout: :two_column_layout
 page /\/v(\d+.\d+)\/(?!bundle_|commands|docs|man)(.*)/, layout: :two_column_layout
 page /\/v(.*)\/man\/(.*)/, layout: :two_column_layout
 page /man\/(.*)/, layout: :two_column_layout

--- a/lib/tasks/versions.rake
+++ b/lib/tasks/versions.rake
@@ -15,14 +15,16 @@ namespace :versions do
     last = VERSIONS.last
     succ = VERSIONS.last.succ
     puts "Latest version is #{last}. Creating version #{succ}..."
-    cp_r "source/#{last}", "source/#{succ}"
+    last_root = "source/#{last}"
+    succ_root = "source/#{succ}"
+    cp_r last_root, succ_root
     puts "Creating empty What's New page..."
     render_whats_new(succ)
     puts "Creating announcement blog post..."
     sh "middleman article 'Bundler #{succ}'"
     puts "Updating latest version symlinks..."
-    Dir.glob("source/#{succ}/man/*.html.erb") do |file|
-      url = file.delete_prefix("source/#{succ}/")
+    Dir.glob("#{succ_root}/man/*.html.erb") do |file|
+      url = file.delete_prefix("#{succ_root}/")
       latest_man = "source/#{url}"
       FileUtils.ln_sf Pathname.new(file).relative_path_from(File.dirname(latest_man)), latest_man
     end

--- a/lib/tasks/versions.rake
+++ b/lib/tasks/versions.rake
@@ -28,6 +28,8 @@ namespace :versions do
       latest_man = "source/#{url}"
       FileUtils.ln_sf Pathname.new(file).relative_path_from(File.dirname(latest_man)), latest_man
     end
+    puts "Updating whats_new symlink..."
+    FileUtils.ln_sf Pathname.new("#{succ_root}/whats_new.html.md").relative_path_from("source"), "source/whats_new.html.md"
   end
 end
 

--- a/source/guides/getting_started.html.md
+++ b/source/guides/getting_started.html.md
@@ -10,7 +10,7 @@ Bundler is an exit from dependency hell, and ensures that the gems
 you need are present in development, staging, and production.
 Starting work on a project is as simple as `bundle install`.
 
-<a href="../v2.4/whats_new.html" class="btn btn-primary">What's new in Bundler</a>
+<a href="../whats_new.html" class="btn btn-primary">What's new in Bundler</a>
 <a href="./rationale.html" class="btn btn-primary">Why Bundler exists</a>
 
 ## Getting Started

--- a/source/whats_new.html.md
+++ b/source/whats_new.html.md
@@ -1,0 +1,1 @@
+v2.6/whats_new.html.md


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the [getting started page](https://bundler.io/guides/getting_started.html) includes a link to [Bundler 2.4 what's new page](https://bundler.io/v2.4/whats_new.html).

Instead, it should link to the latest version.

### What was your diagnosis of the problem?

My diagnosis was that this page started being missing when it was migrated to HAML in f2c455dd48ee6ea4b9aaf4a8ba0c5528e6658d0d, because we create proxy pages, but only for `.haml` pages:

https://github.com/rubygems/bundler-site/blob/cf57e550ade5164282539fb15676c9d72dd2ce98/config.rb#L49-L58

It was replaced with a hardcoded link to the v2.4 version, which was the latest at the time, but it got out of date.

### What is your fix for the problem, implemented in this PR?

My fix is to create a symlink like we did in #1424.

### Why did you choose this fix out of the possible options?

I chose this fix because because it's more SEO friendly that a client side redirect.