### PR TITLE
Fix transformation of some relative links

### DIFF
--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -8,7 +8,7 @@ require "pathname"
 # [Heroku support](http://www.heroku.com/support)
 RELATIVE_LINK_REGEX = %r{
   \[(?<title>.*)\]            # Match title
-  \((?<link>[^(http)].*?)\)   # Match all non-http links
+  \((?<link>(?!http).*?)\)    # Match all non-http links
 }x
 
 def new_link(file, link)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was some links in the doc folder imported from rubygems/rubygems were not being properly adapted to the site structure.

### What was your diagnosis of the problem?

My diagnosis was that the regexp to detect relative links not starting with http was incorrect, because it would fail to detect any link with target starting with "h", "t", or "p" as relative.

### What is your fix for the problem, implemented in this PR?

My fix is to properly use a negative lookahead.

This PR fixes #844. It depends on #1430 since that restore the whole page hierarchy under `/doc`.
