### PR TITLE
Use kramdown GFM parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "middleman-syntax"
 ## Template engines
 gem "builder"
 gem "haml", "~> 6.3"
-gem "kramdown"
+gem "kramdown-parser-gfm"
 
 # Rake tasks
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ DEPENDENCIES
   haml (~> 6.3)
   haml_lint (~> 0.59)
   irb
-  kramdown
+  kramdown-parser-gfm
   middleman!
   middleman-blog!
   middleman-search!

--- a/config.rb
+++ b/config.rb
@@ -27,6 +27,7 @@ set :markdown_engine, :kramdown
 
 # Markdown extentions
 set :markdown,
+    input: "GFM",
     autolink: true,
     fenced_code_blocks: true,
     footnotes: true,


### PR DESCRIPTION


### What was the end-user problem that led to this PR?

The problem was that some markdown pages are not rendered correctly,

### What was your diagnosis of the problem?

We're using options that are exclusive to that parser, so we should explicitly force it.

### What is your fix for the problem, implemented in this PR?

My fix is to explicit set the parser that we want.

Before:

<img width="993" alt="Captura de pantalla 2025-01-20 a las 16 31 23" src="https://github.com/user-attachments/assets/03882ca0-4351-4480-9131-dfeefb1844d0" />

After:

<img width="1009" alt="Captura de pantalla 2025-01-20 a las 16 32 02" src="https://github.com/user-attachments/assets/42504816-9236-47c3-b75f-fde73456d114" />


### Why did you choose this fix out of the possible options?

I chose this fix because it's the simplest approach. Maybe middleman or kramdown could do better at validating options, but I'm leaving it as is for now.
