### PR TITLE
Restore new line behavior with GFM parser

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -38,7 +38,8 @@ set :markdown,
     smartypants: true,
     strikethrough: true,
     superscript: true,
-    tables: true
+    tables: true,
+    hard_wrap: false
 
 # Webpack
 activate :external_pipeline,


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was after switching to GFM markdown parser in #1436, our new lines got messed up:

<img width="886" alt="Captura de pantalla 2025-01-22 a las 10 28 08" src="https://github.com/user-attachments/assets/14f5a24c-80df-4ab7-a4cb-cfda23e78e49" />

### What is your fix for the problem, implemented in this PR?

My fix is to restore the previous appearance by passing the specific option to control line wrap behavior:

<img width="1030" alt="Captura de pantalla 2025-01-22 a las 10 28 26" src="https://github.com/user-attachments/assets/b5dceb3f-adce-4177-a02d-848715d35ffa" />
