### PR TITLE
Improve version selector

### DIFF
--- a/helpers/config_helper.rb
+++ b/helpers/config_helper.rb
@@ -8,7 +8,7 @@ module ConfigHelper
   end
 
   def versions_grouped_by_status
-    versions.reverse.group_by { status(_1) }
+    versions.select {|version| documentation_path(current_page_without_version, version) }.reverse.group_by { status(_1) }
   end
 
   private

--- a/helpers/config_helper.rb
+++ b/helpers/config_helper.rb
@@ -7,8 +7,8 @@ module ConfigHelper
     config[:versions]
   end
 
-  def versions_grouped_by_status
-    versions.select {|version| documentation_path(current_page_without_version, version) }.reverse.group_by { status(_1) }
+  def versions_with_documentation_page
+    versions.select {|version| documentation_path(current_page_without_version, version) }
   end
 
   private

--- a/source/partials/_commands_sidebar.haml
+++ b/source/partials/_commands_sidebar.haml
@@ -6,7 +6,7 @@
     %optgroup{label: status}
       - _versions.each do |version|
         - selected = version == current_visible_version
-        - value = documentation_path(current_page_without_version, version) || documentation_path('bundle-install.1', version)
+        - value = documentation_path(current_page_without_version, version)
         %option{selected: selected, value: value}
           = version
 %h4 General

--- a/source/partials/_commands_sidebar.haml
+++ b/source/partials/_commands_sidebar.haml
@@ -3,9 +3,9 @@
 - if versions_with_documentation_page.size > 1
   %h4 Choose version
   %select.version-selects.form-select.mb-3
-    - versions_with_documentation_page.reverse.group_by { status(_1) }.each do |status, _versions|
+    - versions_with_documentation_page.reverse.group_by { status(_1) }.each do |status, versions|
       %optgroup{label: status}
-        - _versions.each do |version|
+        - versions.each do |version|
           - selected = version == current_visible_version
           - value = documentation_path(current_page_without_version, version)
           %option{selected: selected, value: value}

--- a/source/partials/_commands_sidebar.haml
+++ b/source/partials/_commands_sidebar.haml
@@ -1,14 +1,15 @@
 - primary_commands = %w(bundle-install.1 bundle-update.1 bundle-cache.1 bundle-exec.1 bundle-config.1 bundle-help.1)
 
-%h4 Choose version
-%select.version-selects.form-select.mb-3
-  - versions_grouped_by_status.each do |status, _versions|
-    %optgroup{label: status}
-      - _versions.each do |version|
-        - selected = version == current_visible_version
-        - value = documentation_path(current_page_without_version, version)
-        %option{selected: selected, value: value}
-          = version
+- if versions_with_documentation_page.size > 1
+  %h4 Choose version
+  %select.version-selects.form-select.mb-3
+    - versions_with_documentation_page.reverse.group_by { status(_1) }.each do |status, _versions|
+      %optgroup{label: status}
+        - _versions.each do |version|
+          - selected = version == current_visible_version
+          - value = documentation_path(current_page_without_version, version)
+          %option{selected: selected, value: value}
+            = version
 %h4 General
 %ul
   %li{class: current_page.url.end_with?("whats_new.html") ? "active" : ""}


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we browsing bundler CLI command documentation, and using the version selector, you'll be redirected to `bundle install` page if the current command is not present in the chosen version.

That is unexpected to me, since the intention when performing that action is to browse the documentation for the same command, but a different version of Bundler.

### What is your fix for the problem, implemented in this PR?

My fix is only include versions in the selector that have the current command, and to not show the selector at all if the current version is the only one defining the command.