### PR TITLE
known plugins: add bundler-versions_report

### DIFF
--- a/data/known_plugins.yml
+++ b/data/known_plugins.yml
@@ -63,6 +63,9 @@
 - :name: bundler-symlink
   :summary: Post-install hook for bundler to symlink to all gems from a local directory
   :uri: https://github.com/petekinnecom/bundler-symlink
+- :name: bundler-versions_report
+  :summary: At the end of `bundle update` report all updated major and minor versions
+  :uri: https://github.com/igneus/bundler-versions_report
 - :name: bundler-why
   :summary: Explains the presence of a dependency.
   :uri: https://github.com/jaredbeck/bundler-why


### PR DESCRIPTION
<!--
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user problem that led to this PR?

There's a potentially useful plugin, but it's not yet listed on the Known Plugins page, making it virtually invisible to the end user.

### What was your diagnosis of the problem?

The plugin was too new to be known and listed.

### What is your fix for the problem, implemented in this PR?

I added a record to the respective YAML data file.

### Why did you choose this fix out of the possible options?

It's the most straightforward one of all I can think of.
