### PR TITLE
Revert "Only add a canonical tag to the latest version of man pages"

### DIFF
--- a/source/layouts/two_column_layout.haml
+++ b/source/layouts/two_column_layout.haml
@@ -1,7 +1,7 @@
 - is_command = command?(current_page.url) || whats_new?(current_page.url)
 - v = current_page.url.scan(/v\d\.\d+/).first || current_version
 
-- if current_page.destination_path.start_with?(current_version)
+- if /v\d\.\d+\//.match?(current_page.destination_path)
   - content_for(:canonical, commands_toplevel_path(current_page.destination_path))
 
 ~ wrap_layout :base do


### PR DESCRIPTION
This reverts commit 50063c7691f5ee0cccabe4a58bb97ed748ed5e56.


### What was the end-user problem that led to this PR?

The problem was that when you google `bundle check`, the first result is https://bundler.io/v2.0/man/bundle-check.1.html. Instead, the first result would be ideally the man page for the latest version, not for a version no longer supported.

### What was your diagnosis of the problem?

My diagnosis was that we should tell google to consider the non versioned URL the canonical page for all versioned ones, so that it always prefer to list that page.

### What is your fix for the problem, implemented in this PR?

My fix is to revert the commit where I stopped doing this. The rationale was that these pages are not identical to each other, but I think canonical is also appropriate for pages with similar content.

### Why did you choose this fix out of the possible options?

I chose this fix because I'd like to see if has the desired effect.
