### PR TITLE
Redirect old issues page to bug report template

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -194,7 +194,7 @@ page /\/doc\/(.*)/, layout: :two_column_layout # Imported from rubygems/bundler
 
 page "/sitemap.xml", layout: false
 
-redirect "issues.html", to: "doc/contributing/issues.html" # Backwards compatibility
+redirect "issues.html", to: "https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md" # Backwards compatibility
 redirect "commands.html", to: "man/bundle.1.html" # Backwards compatibility
 redirect "older_versions.html", to: "whats_new.html" # Backwards compatibility
 redirect "team.html", to: "contributors.html" # https://github.com/rubygems/bundler-site/issues/842


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that issues.html page is 404.

### What was your diagnosis of the problem?

My diagnosis was that the issues page was removed from the source repo at https://github.com/rubygems/rubygems/pull/4980.

### What is your fix for the problem, implemented in this PR?

My fix is to link to the bug report template, since it's the most similar resource that we have.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the 404.