### PR TITLE
Fix version selector sometimes missing

### DIFF
--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -4,8 +4,7 @@ module DocsHelper
   end
 
   def documentation_path(page, version=nil)
-    check_single_page("/man/#{page}.html", version) || check_single_page("/#{page}.html", version) ||
-    check_single_page("/#{normalize_man_page(page)}.html", version)
+    check_single_page("/man#{page}", version) || check_single_page(page, version) || check_single_page(normalize_man_page(page), version)
   end
 
   def link_to_documentation(page, version=nil)
@@ -82,7 +81,7 @@ module DocsHelper
   end
 
   def strip_version_from_url(url)
-    url.scan(/v\d\.\d+\/(.*).html/)&.first&.first || url
+    url.sub(/\A\/v\d\.\d+/, "")
   end
 
   def normalize_man_page(page)


### PR DESCRIPTION





### What was the end-user problem that led to this PR?

The problem was that for urls like `https://bundler.io/man/bundle-install.1.html`, version selector is not currently being displayed.

### What was your diagnosis of the problem?

My diagnosis was...

### What is your fix for the problem, implemented in this PR?

My fix is to make sure all urls received by the helper that finds the documentation page for a version start with `/` and end with `.html`.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes things simpler and more consistent.
