### PR TITLE
Fix documentation links

### DIFF
--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -8,7 +8,7 @@ module DocsHelper
   end
 
   def link_to_documentation(page, version=nil)
-    link_to page.gsub(/_|-/, " ").gsub(/\.\d+$/, ""), documentation_path(page, version)
+    link_to page.gsub(/_|-/, " ").gsub(/\.\d+$/, ""), documentation_path("/#{page}.html", version)
   end
 
   def link_to_editable_version


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the links to commands documentation in https://bundler.io/docs.html got broken after #1457.

### What is your fix for the problem, implemented in this PR?

My fix is to adapt to the change in the `documentation_path` helpers which expects valid paths starting from "/", and ending with ".html".
