### PR TITLE
Fix command categorization

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,12 +2,12 @@ Dir.glob(File.expand_path("../lib/config/*.rb", __FILE__), &method(:require))
 require_relative "lib/versions"
 
 config[:versions] = VERSIONS
-config[:current_version] = config[:versions].last
+config[:latest_version] = config[:versions].last
 
 activate :syntax
 activate :i18n
 activate :search do |search|
-  search.resources = ["index.html", "guides/", "#{config[:current_version]}/", "changelog.html", "compatibility.html", "conduct.html", "contributors.html"]
+  search.resources = ["index.html", "guides/", "#{config[:latest_version]}/", "changelog.html", "compatibility.html", "conduct.html", "contributors.html"]
 
   search.index_path = "search/lunr-index.json"
 
@@ -50,16 +50,16 @@ activate :external_pipeline,
 
 # Make documentation for the latest version available at the top level, too.
 # Any pages with names that conflict with files already at the top level will be skipped.
-Dir.glob("./source/#{config[:current_version]}/*.haml").each do |file_path|
+Dir.glob("./source/#{config[:latest_version]}/*.haml").each do |file_path|
   file_path = file_path.sub(/\.haml$/, "")
 
   page_path = file_path.sub(/^\.\/source\//, "")
-  proxy_path = file_path["./source/#{config[:current_version]}/".length..-1]
+  proxy_path = file_path["./source/#{config[:latest_version]}/".length..-1]
 
   proxy proxy_path, page_path unless file_exist?(proxy_path)
 end
 # Same for localizable
-Dir.glob("./source/localizable/#{config[:current_version]}/**/*").select{ |f| File.file?(f) }.each do |file_path|
+Dir.glob("./source/localizable/#{config[:latest_version]}/**/*").select{ |f| File.file?(f) }.each do |file_path|
   matched = file_path.match(/(localizable\/v\d+.\d+\/(.*)\.(.{2})\.html)/)
   next unless matched
 

--- a/helpers/config_helper.rb
+++ b/helpers/config_helper.rb
@@ -1,6 +1,6 @@
 module ConfigHelper
-  def current_version
-    config[:current_version]
+  def latest_version
+    config[:latest_version]
   end
 
   def versions

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -8,7 +8,7 @@ module DocsHelper
   end
 
   def link_to_documentation(page, version=nil)
-    link_to page.gsub(/_|-/, " ").gsub(/\.\d+$/, ""), documentation_path("/#{page}.html", version)
+    link_to page.gsub(/_|-/, " ").gsub(/\.\d+$/, ""), normalized_documentation_path(page, version)
   end
 
   def link_to_editable_version
@@ -38,8 +38,9 @@ module DocsHelper
   end
 
   def path_exist?(page, version=nil)
-    documentation_path(page, version)
+    documentation_path("/#{page}.html", version)
   end
+  alias_method :normalized_documentation_path, :path_exist?
 
   def other_commands(primary_commands, version=nil)
     version ||= current_version

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -24,11 +24,11 @@ module DocsHelper
       path = "bundler/lib/bundler/man/#{filename}.ronn"
       link_to_source("rubygems/rubygems", path)
     elsif %r{\A(?<version>v\d+\.\d+)/man/(?<filename>(bundle[_-]|gemfile)[^/]*)\.html} =~ path
-      if version == current_version
+      if version == latest_version
         path = "bundler/lib/bundler/man/#{filename}.ronn"
         link_to_source("rubygems/rubygems", path)
       else
-        path = path.sub(version, current_version)
+        path = path.sub(version, latest_version)
         link_to_latest(path)
       end
     else
@@ -43,7 +43,7 @@ module DocsHelper
   alias_method :normalized_documentation_path, :path_exist?
 
   def other_commands(primary_commands, version=nil)
-    version ||= current_version
+    version ||= latest_version
 
     current_man_pages = sitemap.resources.select{ |page| page.path.start_with?("#{version}/man/bundle-") }
     commands_from_man = current_man_pages.map{ |page| strip_man_path_to_page(page.path) } # ex: bundle-config.1
@@ -54,7 +54,7 @@ module DocsHelper
   end
 
   def current_visible_version
-    current_page.url.scan(/v\d\.\d+/).first || current_version
+    current_page.url.scan(/v\d\.\d+/).first || latest_version
   end
 
   def current_page_without_version
@@ -96,7 +96,7 @@ module DocsHelper
   end
 
   def check_single_page(path_part, version)
-    path = "/#{version || current_version}#{path_part}"
+    path = "/#{version || latest_version}#{path_part}"
     sitemap.find_resource_by_path(path) ? path : nil
   end
 end

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -54,7 +54,11 @@ module DocsHelper
   end
 
   def current_visible_version
-    current_page.url.scan(/v\d\.\d+/).first || latest_version
+    current_page.url.scan(/v\d\.\d+/).first
+  end
+
+  def current_version
+    current_visible_version || latest_version
   end
 
   def current_page_without_version
@@ -96,7 +100,7 @@ module DocsHelper
   end
 
   def check_single_page(path_part, version)
-    path = "/#{version || latest_version}#{path_part}"
+    path = version ? "/#{version}#{path_part}" : path_part
     sitemap.find_resource_by_path(path) ? path : nil
   end
 end

--- a/helpers/guides_helper.rb
+++ b/helpers/guides_helper.rb
@@ -8,9 +8,9 @@ module GuidesHelper
   end
 
   def guides
-    target_version = current_visible_version > "v1.15" ? "" : "#{current_visible_version}/"
+    target_version = current_version > "v1.15" ? "" : "#{current_version}/"
     guides = Dir.glob("./source/#{target_version}guides/*")
-    target_version = current_visible_version > "v1.15" ? "" : "v1.15/"
+    target_version = current_version > "v1.15" ? "" : "v1.15/"
     localizable_guides = Dir.glob("./source/localizable/#{target_version}guides/*.en.html.md")
     all_guides = guides + localizable_guides + additional_guides
 

--- a/source/layouts/two_column_layout.haml
+++ b/source/layouts/two_column_layout.haml
@@ -1,5 +1,4 @@
 - is_command = command?(current_page.url) || whats_new?(current_page.url)
-- v = current_page.url.scan(/v\d\.\d+/).first || current_version
 
 - if /v\d\.\d+\//.match?(current_page.destination_path)
   - content_for(:canonical, commands_toplevel_path(current_page.destination_path))

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -13,8 +13,8 @@
 
   .d-grid.d-md-flex.gap-2.mx-auto.my-md-4.justify-content-md-center
     = link_to t('home.what_can_bundler_do'), "/guides/getting_started.html#getting-started", class: 'btn btn-primary btn-lg'
-    = link_to "#{t("home.new_in")} #{current_version}", "/#{current_version}/whats_new.html", class: 'btn btn-primary btn-lg'
-    = link_to t('home.cli_docs'), "/#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
+    = link_to "#{t("home.new_in")} #{latest_version}", "/#{latest_version}/whats_new.html", class: 'btn btn-primary btn-lg'
+    = link_to t('home.cli_docs'), "/#{latest_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
     = link_to t('home.chat_with_us'), 'https://join.slack.com/t/bundler/shared_invite/zt-1rrsuuv3m-OmXKWQf8K6iSla4~F1DBjQ', class: 'btn btn-primary btn-lg'
 
 .bg-light-blue
@@ -58,7 +58,7 @@
           $ bundle install
           $ git add Gemfile Gemfile.lock
         .d-grid.d-md-flex.gap-2.my-3.justify-content-md-end
-          = link_to t('home.learn_more_bundle_install'), "./#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
+          = link_to t('home.learn_more_bundle_install'), "./#{latest_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
 
 .bg-light-blue
   .container

--- a/source/partials/_commands_sidebar.haml
+++ b/source/partials/_commands_sidebar.haml
@@ -6,14 +6,14 @@
     - versions_with_documentation_page.reverse.group_by { status(_1) }.each do |status, versions|
       %optgroup{label: status}
         - versions.each do |version|
-          - selected = version == current_visible_version
+          - selected = version == current_version
           - value = documentation_path(current_page_without_version, version)
           %option{selected: selected, value: value}
             = version
 %h4 General
 %ul
   %li{class: current_page.url.end_with?("whats_new.html") ? "active" : ""}
-    = link_to "Release notes", "/#{current_visible_version}/whats_new.html"
+    = link_to "Release notes", normalized_documentation_path("whats_new", current_visible_version)
     %li.separator
       %hr
 %h4 Primary Commands


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was after #1459, commands are no longer properly categorized between "Primary Commands" and "Utilities".

### What is your fix for the problem, implemented in this PR?

My fix is to make sure url normalization to prepend "/" and append ".html" is applied consistently.

I also added other improvements to favor URLs without a version as much as possible since those are guaranteed to have docs for the latest version every time.
