### PR TITLE
Use correct CHANGELOG file

### DIFF
--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -72,6 +72,6 @@ task repo_pages: :update_vendor do
     end
 
     write_file("CODE_OF_CONDUCT.md", File.expand_path("./conduct.html.md", source_dir), title: "RubyGems and Bundler Code of Conduct")
-    write_file("CHANGELOG.md", File.expand_path("./changelog.html.md", source_dir), title: "ChangeLog")
+    write_file("bundler/CHANGELOG.md", File.expand_path("./changelog.html.md", source_dir), title: "ChangeLog")
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

https://bundler.io/changelog.html was showing the rubygems changelog instead of the bundler changelog.

### What was your diagnosis of the problem?

The bundler repository was archived and moved to the a rubygems subdirectory, so I guess that the website code was not updated to reflect the change, and continued reading from the root CHANGELOG.

### What is your fix for the problem, implemented in this PR?

Path changed to point to the right changelog.

### Why did you choose this fix out of the possible options?

I don't see any other options.


After this change:

![image](https://github.com/user-attachments/assets/eb1f8b17-e148-421d-8a65-d31cd2176917)
