### PR TITLE
Clarify gemspec arguments and behaviour.

### DIFF
--- a/source/guides/rubygems.html.md
+++ b/source/guides/rubygems.html.md
@@ -23,25 +23,28 @@ gem "rubocop", "0.79.0"
 In this Gemfile, the `gemspec` method imports gems listed with `add_runtime_dependency` in the `my_gem.gemspec` file, and it also installs rspec and rubocop to test and develop the gem.
 All dependencies from the gemspec and Gemfile will be installed by `bundle install`, but rspec and rubocop will not be included by `gem install mygem` or `bundle add mygem`.
 Runtime dependencies in your gemspec are treated as if they are listed in your Gemfile, and development dependencies are added by default to the group, `:development`.
-You can change that group with the `:development_group` option
+You can change that group with the `:development_group` option:
 
 ~~~ruby
 gemspec :development_group => :dev
 ~~~
 
-As well, you can point to a specific gemspec using `:path`. If your gemspec is in `/gemspec/path`, use
+You can also point to a specific gemspec directory using the `:path` option. If your gemspec is in `/gemspec/path`, use:
 
 ~~~ruby
 gemspec :path => '/gemspec/path'
 ~~~
 
-If you have multiple gemspecs in the same directory, specify which one you'd like to reference using `:name`
+If you omit `:path`, Bundler will look for gemspecs in the same directory as the Gemfile (usually the project root).
+
+If you have multiple gemspecs in the same directory, specify which one you'd like to reference using `:name`. This refers to the gem name **declared inside the gemspec**, not the gemspec filename:
 
 ~~~ruby
 gemspec :name => 'my_awesome_gem'
 ~~~
 
-This will use `my_awesome_gem.gemspec`
+This will match the gemspec where `spec.name = "my_awesome_gem"`, regardless of whether it's defined in `my_awesome_gem.gemspec` or another file.
+
 That's it! Use bundler when developing your gem, and otherwise, use gemspecs normally!
 
 ~~~


### PR DESCRIPTION
I have found interesting confusion at [rest-client Gemfile](https://github.com/rest-client/rest-client/blob/2c72a2e77e2e87d25ff38feba0cf048d51bd5eca/Gemfile#L3-L7). It tries to load gemspec by filename using `name` argument. I was at first confused why that doesn't work, but I have realized the behaviour is different. Bundler loads all gemspecs at given path and filter them based on name entry in gemspec, not by filename.

Let's update the guides to explain this better.