### PR TITLE
Don't elaborate on Gemfile.lock purpose here, defer to lockfile documenation

### DIFF
--- a/source/localizable/guides/creating_gem.en.html.md
+++ b/source/localizable/guides/creating_gem.en.html.md
@@ -135,9 +135,8 @@ a sandboxed environment. It is best practice to use Bundler to manage our gems s
 have gem version conflicts.
 
 By running `bundle install`, Bundler will generate the **extremely important** _Gemfile.lock_
-file. This file is responsible for ensuring that every system this library is developed on has
-the *exact same* gems. For more information on this file [read "THE GEMFILE.LOCK" section of
-the `bundle install` manpage](/man/bundle-install.1.html#THE-GEMFILE-LOCK).
+file. For more information on this file [read "THE GEMFILE.LOCK" section of the
+`bundle install` manpage](/man/bundle-install.1.html#THE-GEMFILE-LOCK).
 
 Additionally in the `bundle install` output, we will see this line:
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that after 08f2e1376b348483b76bade452915847cc42cb8f, the documentation is no longer accurate, because the sentence "this file is responsible for ensuring that every system this library is developed on has the exact same gems" is only true if the file is committed to source control. Otherwise, each system the library is developed on will have a different set of gems, each with its own Gemfile.lock file.

### What was your diagnosis of the problem?

My diagnosis was that we should, for now, make the documentation not innacurate.

### What is your fix for the problem, implemented in this PR?

My fix is, for now, to completely remove this sentence and instead defer to `Gemfile.lock` documentation, where more context is provided.

Separately, I plan to also expand `Gemfile.lock` documentation to make it less authoritative and explain more approaches commonly used by the community.