### PR TITLE
Use recommend syntax to simulate Bundler v4

### DIFF
--- a/source/v2.7/whats_new.html.md
+++ b/source/v2.7/whats_new.html.md
@@ -7,7 +7,7 @@ This is a summary of the biggest changes. As always, a detailed list of every ch
 
 ## A new setting to simulate the next major version (Bundler 4)
 
-With Bundler 2.7, you can configure `bundle config simulate_version 4` and get
+With Bundler 2.7, you can configure `bundle config set simulate_version 4` and get
 all future Bundler 4 defaults enabled by default. Please do use this setting and
 contribute to Bundler 4 by leaving us feedback.
 


### PR DESCRIPTION
Thanks for Bundler v2.7!

### What was the end-user problem that led to this PR?

I was trying out simulating Bundler v4 and got a deprecated message and copy-pasted from the article gave me this:

```bash
$ bundle config simulate_version 4
[DEPRECATED] Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set simulate_version 4` instead.
```

### What was your diagnosis of the problem?

Used the deprecated syntax

### What is your fix for the problem, implemented in this PR?

Used the non-deprecated syntax

### Why did you choose this fix out of the possible options?

As the deprecated message recommends.
