### PR TITLE
Update Slack invite link for chat support

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -15,7 +15,7 @@
     = link_to t('home.what_can_bundler_do'), "/guides/getting_started.html#getting-started", class: 'btn btn-primary btn-lg'
     = link_to "#{t("home.new_in")} #{latest_version}", "/#{latest_version}/whats_new.html", class: 'btn btn-primary btn-lg'
     = link_to t('home.cli_docs'), "/#{latest_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg'
-    = link_to t('home.chat_with_us'), 'https://join.slack.com/t/bundler/shared_invite/zt-1rrsuuv3m-OmXKWQf8K6iSla4~F1DBjQ', class: 'btn btn-primary btn-lg'
+    = link_to t('home.chat_with_us'), 'https://join.slack.com/t/bundler/shared_invite/zt-3e7ej5qo2-D1KqQpnYTTb6T01G4dK4bA', class: 'btn btn-primary btn-lg'
 
 .bg-light-blue
   .container


### PR DESCRIPTION
- got reported it doesn't work anymore, here's new one, sadly only for 30 days