### PR TITLE
Make v2.7 the current release and rotate supported releases

### DIFF
--- a/helpers/config_helper.rb
+++ b/helpers/config_helper.rb
@@ -16,7 +16,7 @@ module ConfigHelper
   def status(version)
     if version == "v2.7"
       "Current release"
-    elsif %w[v2.6 v2.5 v2.4].include?(version)
+    elsif %w[v2.6 v2.5 v2.4 v2.3].include?(version)
       "Legacy release"
     else
       "Deprecated release"


### PR DESCRIPTION
I noticed the version dropdown on the website shows v2.7 as a 'Deprecated release'.

v2.7 is installed when I do `gem install bundler`, so this is most certainly wrong.

```
➜ gem install bundler
Successfully installed bundler-2.7.2
1 gem installed
```

~~I saw the last update to this version was made in e0d14d26ccc24faa1810cc968b20739becc04a6b, which also dropped the oldest version from 'Legacy release'. I've followed that here too.~~

Before:

![](https://github.com/user-attachments/assets/98c27c77-99ee-444e-99b3-c3683667ecc7)

After:

<img width="338" height="494" alt="Screenshot 2025-09-29 at 1 26 20 pm" src="https://github.com/user-attachments/assets/edc963eb-c52b-4c6f-9665-181d8e068b3a" />