### PR TITLE
Use recommend syntax to run bundle install in Bundler v4

### DIFF
--- a/source/guides/bundler_workflow.html.md
+++ b/source/guides/bundler_workflow.html.md
@@ -95,7 +95,7 @@ look for gems declared in the `Gemfile` at `https://rubygems.org` by default.
 After declaring your first set of dependencies, you tell bundler to go get them:
 
 ~~~
-$ bundle install    # `bundle` is a shortcut for `bundle install`
+$ bundle install
 ~~~
 
 Bundler will connect to `rubygems.org` (and any other sources that you declared),

--- a/source/guides/rationale.html.md
+++ b/source/guides/rationale.html.md
@@ -32,7 +32,7 @@ Next, you declare a few dependencies:
 After declaring your first set of dependencies, you tell bundler to go get them:
 
 ~~~
-$ bundle install    # 'bundle' is a shortcut for 'bundle install'
+$ bundle install
 ~~~
 
 Bundler will connect to `rubygems.org` (and any other sources that you declared)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When I installed Bundler v4 and ran `bundle`, I saw this:

```
$ bundle
In the next version of Bundler, running `bundle` without argument will no longer run `bundle install`.
Instead, the `help` command will be displayed.
If you'd like to keep the previous behaviour please run `bundle config set default_cli_command install --global`.
```
### What was your diagnosis of the problem?

The warning message was straightforward.

### What is your fix for the problem, implemented in this PR?

Followed the deprecation warning and started using `bundle install` instead of just `bundle`.

### Why did you choose this fix out of the possible options?

As the deprecated message recommends. Even though there is the backwards compatibility option, I believe it would be nice to keep the docs up to date with how Bundler uses the command by default.