### PR TITLE
docs: fix 8 typos across docs and stylesheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The site bundler.io is a static site generated using [Middleman](http://middlema
 
 ## Development Set Up
 
-Begin by cloning the repository onto your location machine:
+Begin by cloning the repository onto your local machine:
 
     git clone https://github.com/rubygems/bundler-site.git
 
@@ -35,7 +35,7 @@ To specify the host and/or port, add the --bind-address, -p flag(s):
 
     bundle exec middleman --bind-address 0.0.0.0 -p 8080
 
-Note: the development server will automatically reload pages when they or there associated stylesheets are modified. This feature is enabled in **config.rb**.
+Note: the development server will automatically reload pages when they or their associated stylesheets are modified. This feature is enabled in **config.rb**.
 
 Build the site:
 

--- a/assets/stylesheets/_bootstrap-variable-overrides.scss
+++ b/assets/stylesheets/_bootstrap-variable-overrides.scss
@@ -26,11 +26,11 @@ $btn-border-width: 0;
 
 $font-family-sans-serif: "SancoaleSlab", Times, "Times New Roman", serif;
 
-// Transition workaround for unifying link color and button (btn-primary) in Boostrap 4.6.1
+// Transition workaround for unifying link color and button (btn-primary) in Bootstrap 4.6.1
 $link-color: #337ab7;
 // /Transition workaround
 
-// Transition workaround for text-decoration: underline only for a:hover in Boostrap 5.0
+// Transition workaround for text-decoration: underline only for a:hover in Bootstrap 5.0
 $link-decoration: none;
 $link-hover-decoration: underline;
 // /Transition workaround

--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -9,7 +9,7 @@ $navbar-height: 50px;
   font-display: swap;
 }
 
-// Boostrap 5 customization
+// Bootstrap 5 customization
 // Document: https://getbootstrap.com/docs/5.3/customize/sass/#importing
 // List of SCSS to load: https://github.com/twbs/bootstrap/blob/v5.3.3/scss/bootstrap.scss
 @import "~bootstrap/scss/functions";
@@ -58,7 +58,7 @@ $icon-font-path: '~bootstrap/assets/fonts/bootstrap/';
 @import "~bootstrap/scss/utilities/api";
 
 @import "bootstrap-class-overrides";
-// end of Boostrap 5 customization
+// end of Bootstrap 5 customization
 
 @import "navbar";
 @import "docs";

--- a/source/localizable/about.en.html.md
+++ b/source/localizable/about.en.html.md
@@ -32,7 +32,7 @@ multilingualization is still ongoing.
 We welcome multilingualize more guides and other documentations.
 To get started, move some files existing in `/source`
 or create a file to `/source/localizable`
-to multiligualize
+to multilingualize
 files.
 
 ## Becoming a maintainer of this Web site (namely `rubygems/bundler-site`)

--- a/source/v2.4/whats_new.html.md
+++ b/source/v2.4/whats_new.html.md
@@ -7,7 +7,7 @@ includes context and a more detailed explanation of the changes in this version.
 ### A new PubGrub based resolver
 
 Bundler now uses [pub_grub](https://github.com/jhawthorn/pub_grub) under the
-hood to resolve versions. The most advance algorithm to approach the version
+hood to resolve versions. The most advanced algorithm to approach the version
 solving problem! 💪
 
 ### Generate gems with Rust extensions


### PR DESCRIPTION
## Summary

Fix 8 typos across 5 files:

- `source/v2.4/whats_new.html.md`: `advance` → `advanced`
- `assets/stylesheets/application.css.scss`: `Boostrap` → `Bootstrap` (×2)
- `assets/stylesheets/_bootstrap-variable-overrides.scss`: `Boostrap` → `Bootstrap` (×2)
- `source/localizable/about.en.html.md`: `multiligualize` → `multilingualize`
- `README.md`: `location machine` → `local machine`, `there associated` → `their associated`

No functional changes — documentation and CSS comments only.