### PR TITLE
Follow the Bundler source tree move in ruby/rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Middleman deploy](https://github.com/rubygems/bundler-site/actions/workflows/deploy.yml/badge.svg)](https://github.com/rubygems/bundler-site/deployments/activity_log?environment=github-pages)
 
-bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/rubygems/rubygems) gem.
+bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/ruby/rubygems) gem.
 
 The site bundler.io is a static site generated using [Middleman](http://middlemanapp.com/).
 
-[Bundler's manual pages](https://github.com/rubygems/rubygems/tree/master/bundler/lib/bundler/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
+[Bundler's manual pages](https://github.com/ruby/rubygems/tree/master/lib/bundler/man) document much of its functionality and serve as an important part of the site. They are included via the **Rakefile**.
 
 ## Development Set Up
 

--- a/config.rb
+++ b/config.rb
@@ -197,7 +197,7 @@ page /\/doc\/(.*)/, layout: :two_column_layout # Imported from rubygems/bundler
 
 page "/sitemap.xml", layout: false
 
-redirect "issues.html", to: "https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md" # Backwards compatibility
+redirect "issues.html", to: "https://github.com/ruby/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md" # Backwards compatibility
 redirect "commands.html", to: "man/bundle.1.html" # Backwards compatibility
 redirect "older_versions.html", to: "whats_new.html" # Backwards compatibility
 redirect "team.html", to: "https://guides.rubygems.org/contributing" # https://github.com/rubygems/bundler-site/issues/842

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -19,14 +19,14 @@ module DocsHelper
       dirname = File.dirname(path)
       basename = File.basename(path, ".html.md").upcase
       path = File.join(dirname, "#{basename}.md")
-      link_to_source("rubygems/rubygems", path)
+      link_to_source("ruby/rubygems", path)
     elsif %r{\Aman/(?<filename>(bundle[_-]|gemfile)[^/]*)\.html} =~ path
-      path = "bundler/lib/bundler/man/#{filename}.ronn"
-      link_to_source("rubygems/rubygems", path)
+      path = "lib/bundler/man/#{filename}.ronn"
+      link_to_source("ruby/rubygems", path)
     elsif %r{\A(?<version>v\d+\.\d+)/man/(?<filename>(bundle[_-]|gemfile)[^/]*)\.html} =~ path
       if version == latest_version
-        path = "bundler/lib/bundler/man/#{filename}.ronn"
-        link_to_source("rubygems/rubygems", path)
+        path = "lib/bundler/man/#{filename}.ronn"
+        link_to_source("ruby/rubygems", path)
       else
         path = path.sub(version, latest_version)
         link_to_latest(path)
@@ -73,7 +73,7 @@ module DocsHelper
   private
 
   def link_to_source(repo, path)
-    url = "https://github.com/#{repo}/blob/master/#{path}"
+    url = "https://github.com/#{repo}/blob/HEAD/#{path}"
     link_to("Edit this document on GitHub", url) +
       " if you caught an error or noticed something was missing."
   end

--- a/lib/tasks/man_generator/man.rake
+++ b/lib/tasks/man_generator/man.rake
@@ -9,12 +9,13 @@ task man: :update_vendor do
       man_folder = "man"
     elsif version == "v4.0"
       branch = "master"
-      vendor_folder = "vendor/rubygems/bundler"
+      vendor_folder = "vendor/rubygems"
+      # The Bundler tree was moved to the repository root on master.
       man_folder = "lib/bundler/man"
     else
       branch = Gem::Version.new(version[1..-1]).segments.map.with_index { |segment, i| i == 0 ? segment + 1 : segment }.join(".")
-      vendor_folder = "vendor/rubygems/bundler"
-      man_folder = "lib/bundler/man"
+      vendor_folder = "vendor/rubygems"
+      man_folder = "bundler/lib/bundler/man"
     end
 
     # v2.3 or later versions do not have `man` dir even after #922.

--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -50,7 +50,7 @@ directory "vendor/bundler" => ["vendor"] do
 end
 
 directory "vendor/rubygems" => ["vendor"] do
-  system "git clone --depth 1 --no-single-branch https://github.com/rubygems/rubygems.git vendor/rubygems"
+  system "git clone --depth 1 --no-single-branch https://github.com/ruby/rubygems.git vendor/rubygems"
 end
 
 task update_vendor: ["vendor/bundler", "vendor/rubygems"] do
@@ -72,6 +72,6 @@ task repo_pages: :update_vendor do
     end
 
     write_file("CODE_OF_CONDUCT.md", File.expand_path("./conduct.html.md", source_dir), title: "RubyGems and Bundler Code of Conduct")
-    write_file("bundler/CHANGELOG.md", File.expand_path("./changelog.html.md", source_dir), title: "ChangeLog")
+    write_file("CHANGELOG-bundler.md", File.expand_path("./changelog.html.md", source_dir), title: "ChangeLog")
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundler-site",
   "version": "1.0.0",
-  "description": "bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/rubygems/rubygems) gem.",
+  "description": "bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/ruby/rubygems) gem.",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -4,4 +4,4 @@
     %li.nav-item= link_to t('navbar.team'), "https://guides.rubygems.org/contributing", class: "nav-link px-3"
     %li.nav-item= link_to t('navbar.blog'), "/blog", class: "nav-link px-3"
     %li.nav-item= link_to t('navbar.about'), "/about.html", class: "nav-link px-3"
-    %li.nav-item= link_to t('navbar.repository'), "https://github.com/rubygems/rubygems/tree/master/bundler", class: "nav-link px-3"
+    %li.nav-item= link_to t('navbar.repository'), "https://github.com/ruby/rubygems", class: "nav-link px-3"

--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -15,4 +15,4 @@
         %li.nav-item= link_to t('navbar.docs'), '/docs.html', class: "nav-link"
         %li.nav-item= link_to t('navbar.team'), 'https://guides.rubygems.org/contributing', class: "nav-link"
         %li.nav-item= link_to t('navbar.blog'), 'https://blog.rubygems.org/', target: '_blank', rel: 'noopener noreferrer', class: "nav-link"
-        %li.nav-item= link_to t('navbar.repository'), 'https://github.com/rubygems/rubygems/tree/master/bundler', target: '_blank', rel: 'noopener noreferrer', class: "nav-link"
+        %li.nav-item= link_to t('navbar.repository'), 'https://github.com/ruby/rubygems', target: '_blank', rel: 'noopener noreferrer', class: "nav-link"

--- a/source/localizable/about.en.html.md
+++ b/source/localizable/about.en.html.md
@@ -13,10 +13,10 @@ layout: two_column_layout
 
 Middleman 4.4 is the core system of this Web site.
 A half of source code is located in `./source`,
-but the other half is located in [rubygems/rubygems/tree/master/bundler/lib/bundler/man"](https://github.com/rubygems/rubygems/tree/master/bundler/lib/bundler/man),
+but the other half is located in [ruby/rubygems/tree/master/lib/bundler/man](https://github.com/ruby/rubygems/tree/master/lib/bundler/man),
 which would be retrieved by executing `bundle exec rake man`.
 
-When the source code is merged to the default branch `master` on GitHub,
+When the source code is merged to the default branch `main` on GitHub,
 [Deploy job on GitHub Actions](https://github.com/rubygems/bundler-site/blob/HEAD/.github/workflows/deploy.yml)
 would automatically build source (HTML, JS, CSS and font) and push them to GitHub Pages.
 Deploy status can be followed in


### PR DESCRIPTION
The `Repository` link on bundler.io points at `https://github.com/rubygems/rubygems/tree/master/bundler`, which 404s now that the Bundler tree lives at the root of `ruby/rubygems`. The same move broke the `Edit this document on GitHub` link on every man page. I switched those to `blob/HEAD` as well, since they now span two repositories whose default branches differ.

While verifying this I found `rake build` is broken too. `rake man` enters `vendor/rubygems/bundler` before checking out the release branch, so it fails whenever the clone sits on `master`, and `rake repo_pages` still reads `bundler/CHANGELOG.md`. The last successful deploy built a `master` commit from twelve minutes before the move landed, so nothing has been published since.

Fixes https://github.com/ruby/rubygems/issues/9718
