### PR TITLE
Point the latest documentation at Bundler 4.0

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -146,6 +146,16 @@ end
   redirect "bundle_#{command}.html", to: "man/bundle-#{command}.1.html"
 end
 
+# `bundle inject` and `bundle viz` were removed in Bundler 4.0, so the top-level manpages
+# that mirror the latest version are gone. Keep their URLs working by pointing them at the
+# last version that still documents them.
+%w[bundle-inject.1 bundle-viz.1].each do |man_page|
+  version = config[:versions].reverse.find{ |v| File.exist?("./source/#{v}/man/#{man_page}.html.erb") }
+  next unless version
+
+  redirect "man/#{man_page}.html", to: "/#{version}/man/#{man_page}.html"
+end
+
 # Redirect meaningless pages proxied for 6 years to the original pages
 # https://github.com/rubygems/bundler-site/issues/807
 config[:versions].each do |version|

--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -25,9 +25,13 @@ module DocsHelper
       if version == latest_version
         path = "lib/bundler/man/#{filename}.ronn"
         link_to_source("ruby/rubygems", path)
-      else
+      elsif path_exist?("man/#{filename}", latest_version)
         path = path.sub(version, latest_version)
         link_to_latest(path)
+      else
+        # The command was removed upstream, so there is nothing to link to and no ronn
+        # file left to edit. `bundle inject` and `bundle viz` are gone as of Bundler 4.0.
+        obsolete_without_latest
       end
     else
       path = File.join "source", path
@@ -81,6 +85,10 @@ module DocsHelper
     "This document is obsolete. " +
       link_to("See the latest version of this document", url) +
       " if you caught an error or noticed something was missing, it may be fixed there."
+  end
+
+  def obsolete_without_latest
+    "This document is obsolete. It describes a command that no longer exists in Bundler #{latest_version.delete_prefix("v")}."
   end
 
   def strip_version_from_url(url)

--- a/source/man/bundle-add.1.html.erb
+++ b/source/man/bundle-add.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-add.1.html.erb
+../v4.0/man/bundle-add.1.html.erb

--- a/source/man/bundle-binstubs.1.html.erb
+++ b/source/man/bundle-binstubs.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-binstubs.1.html.erb
+../v4.0/man/bundle-binstubs.1.html.erb

--- a/source/man/bundle-cache.1.html.erb
+++ b/source/man/bundle-cache.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-cache.1.html.erb
+../v4.0/man/bundle-cache.1.html.erb

--- a/source/man/bundle-check.1.html.erb
+++ b/source/man/bundle-check.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-check.1.html.erb
+../v4.0/man/bundle-check.1.html.erb

--- a/source/man/bundle-clean.1.html.erb
+++ b/source/man/bundle-clean.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-clean.1.html.erb
+../v4.0/man/bundle-clean.1.html.erb

--- a/source/man/bundle-config.1.html.erb
+++ b/source/man/bundle-config.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-config.1.html.erb
+../v4.0/man/bundle-config.1.html.erb

--- a/source/man/bundle-console.1.html.erb
+++ b/source/man/bundle-console.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-console.1.html.erb
+../v4.0/man/bundle-console.1.html.erb

--- a/source/man/bundle-doctor.1.html.erb
+++ b/source/man/bundle-doctor.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-doctor.1.html.erb
+../v4.0/man/bundle-doctor.1.html.erb

--- a/source/man/bundle-env.1.html.erb
+++ b/source/man/bundle-env.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-env.1.html.erb
+../v4.0/man/bundle-env.1.html.erb

--- a/source/man/bundle-exec.1.html.erb
+++ b/source/man/bundle-exec.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-exec.1.html.erb
+../v4.0/man/bundle-exec.1.html.erb

--- a/source/man/bundle-fund.1.html.erb
+++ b/source/man/bundle-fund.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-fund.1.html.erb
+../v4.0/man/bundle-fund.1.html.erb

--- a/source/man/bundle-gem.1.html.erb
+++ b/source/man/bundle-gem.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-gem.1.html.erb
+../v4.0/man/bundle-gem.1.html.erb

--- a/source/man/bundle-help.1.html.erb
+++ b/source/man/bundle-help.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-help.1.html.erb
+../v4.0/man/bundle-help.1.html.erb

--- a/source/man/bundle-info.1.html.erb
+++ b/source/man/bundle-info.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-info.1.html.erb
+../v4.0/man/bundle-info.1.html.erb

--- a/source/man/bundle-init.1.html.erb
+++ b/source/man/bundle-init.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-init.1.html.erb
+../v4.0/man/bundle-init.1.html.erb

--- a/source/man/bundle-inject.1.html.erb
+++ b/source/man/bundle-inject.1.html.erb
@@ -1,1 +1,0 @@
-../v2.7/man/bundle-inject.1.html.erb

--- a/source/man/bundle-install.1.html.erb
+++ b/source/man/bundle-install.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-install.1.html.erb
+../v4.0/man/bundle-install.1.html.erb

--- a/source/man/bundle-issue.1.html.erb
+++ b/source/man/bundle-issue.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-issue.1.html.erb
+../v4.0/man/bundle-issue.1.html.erb

--- a/source/man/bundle-licenses.1.html.erb
+++ b/source/man/bundle-licenses.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-licenses.1.html.erb
+../v4.0/man/bundle-licenses.1.html.erb

--- a/source/man/bundle-list.1.html.erb
+++ b/source/man/bundle-list.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-list.1.html.erb
+../v4.0/man/bundle-list.1.html.erb

--- a/source/man/bundle-lock.1.html.erb
+++ b/source/man/bundle-lock.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-lock.1.html.erb
+../v4.0/man/bundle-lock.1.html.erb

--- a/source/man/bundle-open.1.html.erb
+++ b/source/man/bundle-open.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-open.1.html.erb
+../v4.0/man/bundle-open.1.html.erb

--- a/source/man/bundle-outdated.1.html.erb
+++ b/source/man/bundle-outdated.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-outdated.1.html.erb
+../v4.0/man/bundle-outdated.1.html.erb

--- a/source/man/bundle-platform.1.html.erb
+++ b/source/man/bundle-platform.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-platform.1.html.erb
+../v4.0/man/bundle-platform.1.html.erb

--- a/source/man/bundle-plugin.1.html.erb
+++ b/source/man/bundle-plugin.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-plugin.1.html.erb
+../v4.0/man/bundle-plugin.1.html.erb

--- a/source/man/bundle-pristine.1.html.erb
+++ b/source/man/bundle-pristine.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-pristine.1.html.erb
+../v4.0/man/bundle-pristine.1.html.erb

--- a/source/man/bundle-remove.1.html.erb
+++ b/source/man/bundle-remove.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-remove.1.html.erb
+../v4.0/man/bundle-remove.1.html.erb

--- a/source/man/bundle-show.1.html.erb
+++ b/source/man/bundle-show.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-show.1.html.erb
+../v4.0/man/bundle-show.1.html.erb

--- a/source/man/bundle-update.1.html.erb
+++ b/source/man/bundle-update.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-update.1.html.erb
+../v4.0/man/bundle-update.1.html.erb

--- a/source/man/bundle-version.1.html.erb
+++ b/source/man/bundle-version.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle-version.1.html.erb
+../v4.0/man/bundle-version.1.html.erb

--- a/source/man/bundle-viz.1.html.erb
+++ b/source/man/bundle-viz.1.html.erb
@@ -1,1 +1,0 @@
-../v2.7/man/bundle-viz.1.html.erb

--- a/source/man/bundle.1.html.erb
+++ b/source/man/bundle.1.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/bundle.1.html.erb
+../v4.0/man/bundle.1.html.erb

--- a/source/man/gemfile.5.html.erb
+++ b/source/man/gemfile.5.html.erb
@@ -1,1 +1,1 @@
-../v2.7/man/gemfile.5.html.erb
+../v4.0/man/gemfile.5.html.erb

--- a/source/whats_new.html.md
+++ b/source/whats_new.html.md
@@ -1,1 +1,1 @@
-v2.7/whats_new.html.md
+v4.0/whats_new.html.md


### PR DESCRIPTION
bundler.io/man/ serves Bundler 2.7 documentation even though the site lists 4.0 as the current release. The symlinks under `source/man/` and `source/whats_new.html.md` are refreshed by `versions:create`, and 4.0 was added by hand in #1607 without them.

`bundle inject` and `bundle viz` were removed upstream and have no page under `source/v4.0/man/`, so their URLs now redirect to the last version that documents them. That keeps the existing `/bundle_inject.html` and `/bundle_viz.html` redirects resolving. `link_to_editable_version` pointed obsolete pages at a latest-version URL that no longer exists, so it now says the command is gone rather than linking to a 404.

`bundle exec rake build` fails before Middleman runs because rubygems/rubygems moved the `bundler/` subtree to the repository root in db533d1651. I verified with `middleman build` against pre-generated manpages and will send that fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
