### PR TITLE
Follow the bundler/ subtree move to the rubygems repository root

### DIFF
--- a/helpers/docs_helper.rb
+++ b/helpers/docs_helper.rb
@@ -14,8 +14,6 @@ module DocsHelper
   def link_to_editable_version
     path = current_page.file_descriptor.relative_path.to_s
     if path.start_with?("doc/")
-      path.delete_prefix!("doc/")
-      path.prepend("doc/bundler/")
       dirname = File.dirname(path)
       basename = File.basename(path, ".html.md").upcase
       path = File.join(dirname, "#{basename}.md")

--- a/lib/tasks/vendor_files.rake
+++ b/lib/tasks/vendor_files.rake
@@ -31,8 +31,8 @@ end
 def write_file(file, to, title: nil)
   content = File.read(file)
 
-  file = file.sub("doc/bundler/", "doc/").downcase
-  to = to.sub("doc/bundler/", "doc/").downcase
+  file = file.downcase
+  to = to.downcase
 
   content.gsub!(RELATIVE_LINK_REGEX) do |match_data|
     new_link = new_link(file, Regexp.last_match[:link].downcase)
@@ -65,7 +65,7 @@ task repo_pages: :update_vendor do
     sh "git checkout origin/master"
 
     source_dir = File.expand_path("../source/", File.dirname(__dir__))
-    Dir["doc/bundler/**/*.md"].each do |file|
+    Dir["doc/**/*.md"].each do |file|
       file_name = file[0..-4] # Removes .md suffix
       to = File.expand_path("./#{file_name}.html.md", source_dir)
       write_file(file, to)


### PR DESCRIPTION
`bundle exec rake build` has been failing since rubygems/rubygems moved the `bundler/` subtree to the repository root. `repo_pages` aborted on `bundler/CHANGELOG.md` and `man` aborted on `vendor/rubygems/bundler`.

The doc glob becomes `doc/**/*.md` and the changelog comes from `CHANGELOG-bundler.md`. The man task now chdirs into `vendor/rubygems` and chooses the man folder per branch, because `git checkout` runs after the chdir and release branches 3.2 through 4.0 still keep Bundler under `bundler/`. The edit links drop the `doc/bundler/` and `bundler/` prefixes.

Upstream merged the Bundler and RubyGems docs into one flat `doc/`, so the published set changes. `/doc/contributing/*`, `/doc/development/*` and `/doc/playbooks/*` go away, and `/doc/getting_started.html`, `/doc/issue_triage.html` and `/doc/release.html` appear. Selecting only the Bundler docs is no longer possible upstream. One dangling link remains, `/doc/maintainers.txt` from the merged `doc/README.md`, since the glob skips `.txt`.
