### PR TITLE
Fix two typos in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bundler's manual pages moved to the [command reference on the RubyGems guides](h
 
 ## Development Set Up
 
-Begin by cloning the repository onto your location machine:
+Begin by cloning the repository onto your local machine:
 
     git clone https://github.com/rubygems/bundler-site.git
 
@@ -30,7 +30,7 @@ To specify the host and/or port, add the --bind-address, -p flag(s):
 
     bundle exec middleman --bind-address 0.0.0.0 -p 8080
 
-Note: the development server will automatically reload pages when they or there associated stylesheets are modified. This feature is enabled in **config.rb**.
+Note: the development server will automatically reload pages when they or their associated stylesheets are modified. This feature is enabled in **config.rb**.
 
 Build the site:
 


### PR DESCRIPTION
Picked from #1700, which fixed eight typos. Only these two still apply. The other six touch `assets/stylesheets/application.css.scss`, `assets/stylesheets/_bootstrap-variable-overrides.scss`, `source/localizable/about.en.html.md` and `source/v2.4/whats_new.html.md`, all of which have been removed since that pull request was opened.

The commit keeps `Avicennasis` as the author.
