### PR TITLE
Point the guides redirects at their final URL

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -26,25 +26,44 @@ end
 # Redirect removed guide pages to https://guides.rubygems.org/
 guides_target = "https://guides.rubygems.org/"
 
+# Where each guide this site used to host lives on the guides site now. Most kept their
+# name; the rest were folded into another page there. Pointing at the final URL keeps
+# every redirect below a single hop, instead of landing on a guides redirect stub.
+guides_pages = %w[
+  bundler_docker_guide bundler_in_a_single_file_ruby_script bundler_plugins bundler_setup
+  deploying gemfile gemfile_ruby getting_started git git_bisect groups plugins rails
+  rubygems rubygems_tls_ssl_troubleshooting_guide sinatra updating_gems
+  using_bundler_in_applications
+].to_h { |filename| [filename, "#{guides_target}#{filename}/"] }.merge(
+  "bundler_2_upgrade" => "#{guides_target}faqs/",
+  "bundler_sharing" => "#{guides_target}dependency_management/",
+  "bundler_workflow" => "#{guides_target}dependency_management/",
+  "creating_gem" => "#{guides_target}make-your-own-gem/",
+  "faq" => "#{guides_target}faqs/",
+  "rationale" => "#{guides_target}dependency_management/",
+  "rubymotion" => "#{guides_target}bundler_docker_guide/",
+)
+
 ## /guides/creating_gem.html, /guides/using_bundler_in_applications.html (localizable guides, non-en)
 %w[creating_gem using_bundler_in_applications].each do |filename|
   %w[es pl].each do |lang|
-    redirect "#{lang}/guides/#{filename}.html", to: guides_target
+    redirect "#{lang}/guides/#{filename}.html", to: guides_pages.fetch(filename)
   end
 end
 
 ## Top-level pages that were previously redirected to guides/
 %w[bundler_workflow gemfile_ruby rationale rubygems rubymotion].each do |filename|
-  redirect "#{filename}.html", to: guides_target
+  redirect "#{filename}.html", to: guides_pages.fetch(filename)
 end
 
 ## The Gemfile guide was replaced by the gemfile(5) reference on the guides site.
-redirect "gemfile.html", to: "#{guides_target}gemfile/"
+redirect "gemfile.html", to: guides_pages.fetch("gemfile")
 
 ## /compatibility.html moved to the RubyGems guides
 redirect "compatibility.html", to: "#{guides_target}bundler-compatibility/"
 
-## /v1.12/rails23.html, /v1.12/rails3.html
+## /v1.12/rails23.html, /v1.12/rails3.html. These documented Rails 2.3 and Rails 3, which
+## the guides site never carried, so they land on its index rather than a specific page.
 %w[rails23 rails3].each do |filename|
   redirect "v1.12/#{filename}.html", to: guides_target
 end
@@ -52,24 +71,25 @@ end
 ## Versioned guide redirects for v1.12-v1.14
 %w[1.12 1.13 1.14].each do |version|
   %w[bundler_setup bundler_sharing deploying faq git git_bisect groups rails sinatra updating_gems].each do |filename|
-    redirect "v#{version}/#{filename}.html", to: guides_target
+    redirect "v#{version}/#{filename}.html", to: guides_pages.fetch(filename)
   end
 end
 
 ## Versioned localizable guide redirects for v1.12-v1.15
 %w[1.12 1.13 1.14 1.15].each do |version|
   ["", "pl/"].each do |lang|
-    redirect "#{lang}v#{version}/guides/creating_gem.html", to: guides_target
-    redirect "#{lang}v#{version}/guides/using_bundler_in_applications.html", to: guides_target
+    %w[creating_gem using_bundler_in_applications].each do |filename|
+      redirect "#{lang}v#{version}/guides/#{filename}.html", to: guides_pages.fetch(filename)
+    end
   end
 end
 
 ## v1.15 guides
 %w[bundler_setup bundler_sharing deploying faq git git_bisect groups rails rubygems_tls_ssl_troubleshooting_guide sinatra updating_gems].each do |filename|
-  redirect "v1.15/guides/#{filename}.html", to: guides_target
+  redirect "v1.15/guides/#{filename}.html", to: guides_pages.fetch(filename)
 end
 %w[bundler_setup bundler_sharing].each do |filename|
-  redirect "es/v1.15/guides/#{filename}.html", to: guides_target
+  redirect "es/v1.15/guides/#{filename}.html", to: guides_pages.fetch(filename)
 end
 
 ## Versioned guide redirects for v1.16-v2.3
@@ -79,23 +99,24 @@ end
     bundler_setup bundler_sharing deploying faq git git_bisect groups rails
     rubygems_tls_ssl_troubleshooting_guide sinatra updating_gems
   ].each do |filename|
-    redirect "v#{version}/guides/#{filename}.html", to: guides_target
+    redirect "v#{version}/guides/#{filename}.html", to: guides_pages.fetch(filename)
   end
 
   %w[bundler_workflow gemfile_ruby rationale rubygems rubymotion].each do |filename|
-    redirect "v#{version}/#{filename}.html", to: guides_target
+    redirect "v#{version}/#{filename}.html", to: guides_pages.fetch(filename)
   end
-  redirect "v#{version}/gemfile.html", to: "#{guides_target}gemfile/"
+  redirect "v#{version}/gemfile.html", to: guides_pages.fetch("gemfile")
 
   ["", "pl/"].each do |lang|
-    redirect "#{lang}v#{version}/guides/creating_gem.html", to: guides_target
-    redirect "#{lang}v#{version}/guides/using_bundler_in_applications.html", to: guides_target
+    %w[creating_gem using_bundler_in_applications].each do |filename|
+      redirect "#{lang}v#{version}/guides/#{filename}.html", to: guides_pages.fetch(filename)
+    end
   end
 end
 
 ## v2.0-v2.3 bundler_2_upgrade
 %w[2.0 2.1 2.2 2.3].each do |version|
-  redirect "v#{version}/guides/bundler_2_upgrade.html", to: guides_target
+  redirect "v#{version}/guides/bundler_2_upgrade.html", to: guides_pages.fetch("bundler_2_upgrade")
 end
 
 ## /doc/* pages were imported from the rubygems repo. The Bundler doc tree was merged into the

--- a/source/guides/bundler_2_upgrade.html
+++ b/source/guides/bundler_2_upgrade.html
@@ -6,14 +6,14 @@ layout: false
 <head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://guides.rubygems.org/bundler_2_upgrade/">
-  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/bundler_2_upgrade/">
+  <link rel="canonical" href="https://guides.rubygems.org/faqs/">
+  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/faqs/">
   <style>
     body { font-family: sans-serif; padding: 2rem; }
   </style>
 </head>
 <body>
   <h1>Redirecting&hellip;</h1>
-  <p>The guides have moved to <a href="https://guides.rubygems.org/bundler_2_upgrade/">guides.rubygems.org/bundler_2_upgrade/</a>.</p>
+  <p>The guides have moved to <a href="https://guides.rubygems.org/faqs/">guides.rubygems.org/faqs/</a>.</p>
 </body>
 </html>

--- a/source/guides/bundler_sharing.html
+++ b/source/guides/bundler_sharing.html
@@ -6,14 +6,14 @@ layout: false
 <head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://guides.rubygems.org/bundler_sharing/">
-  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/bundler_sharing/">
+  <link rel="canonical" href="https://guides.rubygems.org/dependency_management/">
+  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/dependency_management/">
   <style>
     body { font-family: sans-serif; padding: 2rem; }
   </style>
 </head>
 <body>
   <h1>Redirecting&hellip;</h1>
-  <p>The guides have moved to <a href="https://guides.rubygems.org/bundler_sharing/">guides.rubygems.org/bundler_sharing/</a>.</p>
+  <p>The guides have moved to <a href="https://guides.rubygems.org/dependency_management/">guides.rubygems.org/dependency_management/</a>.</p>
 </body>
 </html>

--- a/source/guides/bundler_workflow.html
+++ b/source/guides/bundler_workflow.html
@@ -6,14 +6,14 @@ layout: false
 <head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://guides.rubygems.org/bundler_workflow/">
-  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/bundler_workflow/">
+  <link rel="canonical" href="https://guides.rubygems.org/dependency_management/">
+  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/dependency_management/">
   <style>
     body { font-family: sans-serif; padding: 2rem; }
   </style>
 </head>
 <body>
   <h1>Redirecting&hellip;</h1>
-  <p>The guides have moved to <a href="https://guides.rubygems.org/bundler_workflow/">guides.rubygems.org/bundler_workflow/</a>.</p>
+  <p>The guides have moved to <a href="https://guides.rubygems.org/dependency_management/">guides.rubygems.org/dependency_management/</a>.</p>
 </body>
 </html>

--- a/source/guides/creating_gem.html
+++ b/source/guides/creating_gem.html
@@ -6,14 +6,14 @@ layout: false
 <head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://guides.rubygems.org/creating_gem/">
-  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/creating_gem/">
+  <link rel="canonical" href="https://guides.rubygems.org/make-your-own-gem/">
+  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/make-your-own-gem/">
   <style>
     body { font-family: sans-serif; padding: 2rem; }
   </style>
 </head>
 <body>
   <h1>Redirecting&hellip;</h1>
-  <p>The guides have moved to <a href="https://guides.rubygems.org/creating_gem/">guides.rubygems.org/creating_gem/</a>.</p>
+  <p>The guides have moved to <a href="https://guides.rubygems.org/make-your-own-gem/">guides.rubygems.org/make-your-own-gem/</a>.</p>
 </body>
 </html>

--- a/source/guides/faq.html
+++ b/source/guides/faq.html
@@ -6,14 +6,14 @@ layout: false
 <head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://guides.rubygems.org/faq/">
-  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/faq/">
+  <link rel="canonical" href="https://guides.rubygems.org/faqs/">
+  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/faqs/">
   <style>
     body { font-family: sans-serif; padding: 2rem; }
   </style>
 </head>
 <body>
   <h1>Redirecting&hellip;</h1>
-  <p>The guides have moved to <a href="https://guides.rubygems.org/faq/">guides.rubygems.org/faq/</a>.</p>
+  <p>The guides have moved to <a href="https://guides.rubygems.org/faqs/">guides.rubygems.org/faqs/</a>.</p>
 </body>
 </html>

--- a/source/guides/rationale.html
+++ b/source/guides/rationale.html
@@ -6,14 +6,14 @@ layout: false
 <head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://guides.rubygems.org/rationale/">
-  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/rationale/">
+  <link rel="canonical" href="https://guides.rubygems.org/dependency_management/">
+  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/dependency_management/">
   <style>
     body { font-family: sans-serif; padding: 2rem; }
   </style>
 </head>
 <body>
   <h1>Redirecting&hellip;</h1>
-  <p>The guides have moved to <a href="https://guides.rubygems.org/rationale/">guides.rubygems.org/rationale/</a>.</p>
+  <p>The guides have moved to <a href="https://guides.rubygems.org/dependency_management/">guides.rubygems.org/dependency_management/</a>.</p>
 </body>
 </html>

--- a/source/guides/rubymotion.html
+++ b/source/guides/rubymotion.html
@@ -6,14 +6,14 @@ layout: false
 <head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://guides.rubygems.org/rubymotion/">
-  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/rubymotion/">
+  <link rel="canonical" href="https://guides.rubygems.org/bundler_docker_guide/">
+  <meta http-equiv="refresh" content="0; url=https://guides.rubygems.org/bundler_docker_guide/">
   <style>
     body { font-family: sans-serif; padding: 2rem; }
   </style>
 </head>
 <body>
   <h1>Redirecting&hellip;</h1>
-  <p>The guides have moved to <a href="https://guides.rubygems.org/rubymotion/">guides.rubygems.org/rubymotion/</a>.</p>
+  <p>The guides have moved to <a href="https://guides.rubygems.org/bundler_docker_guide/">guides.rubygems.org/bundler_docker_guide/</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
The guides site merged several of the pages this site hands off to, so its old URLs are redirect stubs of their own and visitors take two hops before reaching real content. Each handoff now goes straight to the surviving page.

Checked against the live site, `faq` and `bundler_2_upgrade` resolve to `faqs/`, `bundler_sharing`, `bundler_workflow` and `rationale` to `dependency_management/`, `creating_gem` to `make-your-own-gem/`, and `rubymotion` to `bundler_docker_guide/`.

The versioned redirects in `config.rb` used to drop everyone on the guides index. They now reach the matching guide, resolved through a single `guides_pages` table so the renamed targets are not repeated across the redirect blocks. Only `/v1.12/rails23.html` and `/v1.12/rails3.html` still land on the index, since the guides site never carried Rails 2.3 or Rails 3.
